### PR TITLE
Add basic support for AudioOnly formats

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
@@ -6,6 +6,7 @@
         High,
         Medium,
         Low,
-        Mobile
+        Mobile,
+        AudioOnly
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoResolution.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoResolution.cs
@@ -7,6 +7,7 @@ namespace TwitchLeecher.Core.Models
         #region Constants
 
         private const string UNKNOWN = "Unknown";
+        private const string NOTAVAILABLE = "N/A";
 
         #endregion Constants
 
@@ -38,7 +39,7 @@ namespace TwitchLeecher.Core.Models
             }
             else
             {
-                this.resolutionFps = UNKNOWN;
+                this.resolutionFps = videoQuality == VideoQuality.AudioOnly ? NOTAVAILABLE : UNKNOWN;
             }
         }
 

--- a/TwitchLeecher/TwitchLeecher.Services/Extensions/VideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Extensions/VideoQuality.cs
@@ -24,6 +24,9 @@ namespace TwitchLeecher.Services.Extensions
                 case VideoQuality.Mobile:
                     return "mobile";
 
+                case VideoQuality.AudioOnly:
+                    return "audio_only";
+
                 default:
                     throw new ApplicationException("Cannot convert enum value '" + videoQuality.ToString() + "' to Twitch quality string!");
             }

--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -31,7 +31,7 @@ namespace TwitchLeecher.Services.Services
         private const string usersUrl = "https://api.twitch.tv/kraken/users/{0}";
         private const string videosUrl = "https://api.twitch.tv/kraken/channels/{0}/videos";
         private const string accessTokenUrl = "https://api.twitch.tv/api/vods/{0}/access_token";
-        private const string allPlaylistsUrl = "https://usher.twitch.tv/vod/{0}?nauthsig={1}&nauth={2}&allow_source=true&player=twitchweb&allow_spectre=true";
+        private const string allPlaylistsUrl = "https://usher.twitch.tv/vod/{0}?nauthsig={1}&nauth={2}&allow_source=true&player=twitchweb&allow_spectre=true&allow_audio_only=true";
 
         private const string TEMP_PREFIX = "TL_";
         private const string PLAYLIST_NAME = "vod.m3u8";
@@ -98,6 +98,7 @@ namespace TwitchLeecher.Services.Services
             this.orderMap.Add(VideoQuality.Medium, 2);
             this.orderMap.Add(VideoQuality.Low, 3);
             this.orderMap.Add(VideoQuality.Mobile, 4);
+            this.orderMap.Add(VideoQuality.AudioOnly, 5);
 
             this.downloadTimer = new Timer(this.DownloadTimerCallback, null, 0, TIMER_INTERVALL);
 
@@ -857,6 +858,11 @@ namespace TwitchLeecher.Services.Services
                             break;
                     }
                 }
+            }
+
+            if (fpsList.ContainsKey("audio_only"))
+            {
+                resolutions.Add(new TwitchVideoResolution(VideoQuality.AudioOnly, null, null));
             }
 
             if (!resolutions.Any())


### PR DESCRIPTION
Not sure what is your policy on non-video formats but this PR somewhat adds basic support for AudioOnly format (available via specifying `allow_audio_only` query parameter in `allPlaylistsUrl`).
In fact it does not fit so well in current object model so fell free to reject if you are not OK with this semi-hack solution.