### PR TITLE
Improve user existence check

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -28,7 +28,7 @@ namespace TwitchLeecher.Services.Services
     {
         #region Constants
 
-        private const string usersUrl = "https://api.twitch.tv/kraken/users/{0}";
+        private const string channelsUrl = "https://api.twitch.tv/api/channels/{0}";
         private const string videosUrl = "https://api.twitch.tv/kraken/channels/{0}/videos";
         private const string accessTokenUrl = "https://api.twitch.tv/api/vods/{0}/access_token";
         private const string allPlaylistsUrl = "https://usher.twitch.tv/vod/{0}?nauthsig={1}&nauth={2}&allow_source=true&player=twitchweb&allow_spectre=true";
@@ -147,7 +147,7 @@ namespace TwitchLeecher.Services.Services
             {
                 try
                 {
-                    string result = webClient.DownloadString(string.Format(usersUrl, username));
+                    string result = webClient.DownloadString(string.Format(channelsUrl, username));
                     return true;
                 }
                 catch


### PR DESCRIPTION
Currently inputting `kevindd` in `Search -> Channel Name:` produces unexpected error (see screenshot):

![image](https://cloud.githubusercontent.com/assets/1908898/15902214/08cc5a76-2dd1-11e6-9598-e0784b1bbc66.png)

Namely this crash happens [here](https://github.com/Franiac/TwitchLeecher/blob/master/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs#L180).

The problem here is that there is no such channel `kevindd` exists and this is clearly stated by https://www.twitch.tv/kevindd. However [users API](https://github.com/Franiac/TwitchLeecher/blob/master/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs#L31) (that is currently [used for user existence check](https://github.com/Franiac/TwitchLeecher/blob/master/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs#L150)) reports user is OK: https://api.twitch.tv/kraken/users/kevindd.

This PR switches to [channels API](https://github.com/dstftw/TwitchLeecher/blob/564313812dc67d290143847399b335839a506d9b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs#L31) for user existence check that correctly reports that channel `kevindd` is not available: https://api2.twitch.tv/api/channels/kevindd/ember.

After all Twitch itself uses channels API for that check.