### PR TITLE
Issue #145 - Use the modern save file dialog

### DIFF
--- a/TwitchLeecher.Setup/TwitchLeecher.Setup.Msi.Shared/Features/FeatureTL.wxs
+++ b/TwitchLeecher.Setup/TwitchLeecher.Setup.Msi.Shared/Features/FeatureTL.wxs
@@ -37,6 +37,12 @@
         <File Id="TL_FontAwesome.WPF.dll" KeyPath="yes" Source="$(var.TL_SOURCE_DIR)FontAwesome.WPF.dll" />
       </Component>
       <Component Directory="INSTALLDIR">
+        <File Id="TL_Microsoft.WindowsAPICodePack.dll" KeyPath="yes" Source="$(var.TL_SOURCE_DIR)Microsoft.WindowsAPICodePack.dll" />
+      </Component>
+      <Component Directory="INSTALLDIR">
+        <File Id="TL_Microsoft.WindowsAPICodePack.Shell.dll" KeyPath="yes" Source="$(var.TL_SOURCE_DIR)Microsoft.WindowsAPICodePack.Shell.dll" />
+      </Component>
+      <Component Directory="INSTALLDIR">
         <File Id="TL_Newtonsoft.Json.dll" KeyPath="yes" Source="$(var.TL_SOURCE_DIR)Newtonsoft.Json.dll" />
       </Component>
       <Component Directory="INSTALLDIR">

--- a/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
@@ -9,6 +9,7 @@ using TwitchLeecher.Gui.Views;
 using TwitchLeecher.Services.Interfaces;
 using Cursors = System.Windows.Input.Cursors;
 using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
+using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace TwitchLeecher.Gui.Services
 {
@@ -87,16 +88,33 @@ namespace TwitchLeecher.Gui.Services
 
         public void ShowFolderBrowserDialog(string folder, Action<bool, string> dialogCompleteCallback)
         {
-            using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+            if (CommonOpenFileDialog.IsPlatformSupported)
             {
+                CommonOpenFileDialog cofd = new CommonOpenFileDialog();
+                cofd.IsFolderPicker = true;
+
                 if (!string.IsNullOrWhiteSpace(folder))
                 {
-                    fbd.SelectedPath = folder;
+                    cofd.InitialDirectory = folder;
                 }
 
-                DialogResult result = fbd.ShowDialog();
+                CommonFileDialogResult result = cofd.ShowDialog();
 
-                dialogCompleteCallback(result != DialogResult.OK, fbd.SelectedPath);
+                dialogCompleteCallback(result != CommonFileDialogResult.Ok, cofd.FileName);
+            }
+            else
+            {
+                using (FolderBrowserDialog fbd = new FolderBrowserDialog())
+                {
+                    if (!string.IsNullOrWhiteSpace(folder))
+                    {
+                        fbd.SelectedPath = folder;
+                    }
+
+                    DialogResult result = fbd.ShowDialog();
+
+                    dialogCompleteCallback(result != DialogResult.OK, fbd.SelectedPath);
+                }
             }
         }
 

--- a/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Services/DialogService.cs
@@ -1,4 +1,5 @@
-﻿using Ninject;
+﻿using Microsoft.WindowsAPICodePack.Dialogs;
+using Ninject;
 using System;
 using System.Windows;
 using System.Windows.Forms;
@@ -9,7 +10,6 @@ using TwitchLeecher.Gui.Views;
 using TwitchLeecher.Services.Interfaces;
 using Cursors = System.Windows.Input.Cursors;
 using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
-using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace TwitchLeecher.Gui.Services
 {
@@ -88,19 +88,23 @@ namespace TwitchLeecher.Gui.Services
 
         public void ShowFolderBrowserDialog(string folder, Action<bool, string> dialogCompleteCallback)
         {
-            if (CommonOpenFileDialog.IsPlatformSupported)
+            if (CommonFileDialog.IsPlatformSupported)
             {
-                CommonOpenFileDialog cofd = new CommonOpenFileDialog();
-                cofd.IsFolderPicker = true;
-
-                if (!string.IsNullOrWhiteSpace(folder))
+                using (CommonOpenFileDialog cofd = new CommonOpenFileDialog())
                 {
-                    cofd.InitialDirectory = folder;
+                    cofd.IsFolderPicker = true;
+
+                    if (!string.IsNullOrWhiteSpace(folder))
+                    {
+                        cofd.InitialDirectory = folder;
+                    }
+
+                    CommonFileDialogResult result = cofd.ShowDialog();
+
+                    bool canceled = result != CommonFileDialogResult.Ok;
+
+                    dialogCompleteCallback(canceled, canceled ? null : cofd.FileName);
                 }
-
-                CommonFileDialogResult result = cofd.ShowDialog();
-
-                dialogCompleteCallback(result != CommonFileDialogResult.Ok, cofd.FileName);
             }
             else
             {

--- a/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
+++ b/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
@@ -41,6 +41,12 @@
     <Reference Include="FontAwesome.WPF, Version=4.7.0.37774, Culture=neutral, PublicKeyToken=0758b07a11a4f466, processorArchitecture=MSIL">
       <HintPath>..\packages\FontAwesome.WPF.4.7.0.9\lib\net40\FontAwesome.WPF.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack">
+      <HintPath>..\packages\WindowsAPICodePack-Core.1.1.1\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell">
+      <HintPath>..\packages\WindowsAPICodePack-Shell.1.1.1\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
     <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
       <Private>True</Private>

--- a/TwitchLeecher/TwitchLeecher.Gui/packages.config
+++ b/TwitchLeecher/TwitchLeecher.Gui/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="FontAwesome.WPF" version="4.7.0.9" targetFramework="net45" />
   <package id="Ninject" version="3.2.2.0" targetFramework="net45" />
+  <package id="WindowsAPICodePack-Core" version="1.1.1" targetFramework="net45" />
+  <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Support using the CommonOpenFileDialog as a folder picker when choosing directories.  This behavior relies on the Windows API Code Pack which is provided by NuGet.  Since this dialog is only available on Vista and later a test which will fall back to the older Windows Forms dialog is included.

I welcome your review and any feedback you might have.