### PR TITLE
Improve channel name validation

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchViewVM.cs
@@ -199,10 +199,16 @@ namespace TwitchLeecher.Gui.ViewModels
                 SearchParams.Validate();
 
                 if (SearchParams.SearchType == SearchType.Channel &&
-                    !string.IsNullOrWhiteSpace(SearchParams.Channel) &&
-                    !_twitchService.ChannelExists(SearchParams.Channel))
+                    !string.IsNullOrWhiteSpace(SearchParams.Channel))
                 {
-                    SearchParams.AddError(nameof(SearchParams.Channel), "The specified channel does not exist on Twitch!");
+                    if (!_twitchService.ChannelNameIsValid(SearchParams.Channel))
+                    {
+                        SearchParams.AddError(nameof(SearchParams.Channel), "Invalid channel name!");
+                    }
+                    else if (!_twitchService.ChannelExists(SearchParams.Channel))
+                    {
+                        SearchParams.AddError(nameof(SearchParams.Channel), "The specified channel does not exist on Twitch!");
+                    }
                 }
 
                 if (SearchParams.HasErrors)

--- a/TwitchLeecher/TwitchLeecher.Services/Interfaces/ITwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Interfaces/ITwitchService.cs
@@ -20,6 +20,8 @@ namespace TwitchLeecher.Services.Interfaces
 
         VodAuthInfo RetrieveVodAuthInfo(string id);
 
+        bool ChannelNameIsValid(string channel);
+
         bool ChannelExists(string channel);
 
         string GetChannelIdByName(string channel);

--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -56,6 +57,8 @@ namespace TwitchLeecher.Services.Services
         private const string TWITCH_V5_ACCEPT = "application/vnd.twitchtv.v5+json";
         private const string TWITCH_V5_ACCEPT_HEADER = "Accept";
         private const string TWITCH_AUTHORIZATION_HEADER = "Authorization";
+
+        private const string USERNAME_REGEX = @"^[a-zA-Z0-9][\w]{2,24}$";
 
         #endregion Constants
 
@@ -263,6 +266,16 @@ namespace TwitchLeecher.Services.Services
 
                 return new VodAuthInfo(token, signature, privileged, subOnly);
             }
+        }
+
+        public bool ChannelNameIsValid(string channel)
+        {
+            if (string.IsNullOrWhiteSpace(channel))
+            {
+                throw new ArgumentNullException(nameof(channel));
+            }
+
+            return Regex.IsMatch(channel, USERNAME_REGEX);
         }
 
         public bool ChannelExists(string channel)


### PR DESCRIPTION
Resolves #200
Twitch allow only letters, numbers and underscores(between 3 and 25 characters).
Username/channel cannot be starts with an underscore.