### PR TITLE
Autosplit video and some other other updates.

### DIFF
--- a/TwitchLeecher/GlobalAssemblyInfo.cs
+++ b/TwitchLeecher/GlobalAssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Franiac")]
 [assembly: AssemblyCopyright("Copyright © 2018 Dominik Rebitzer")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.7.0")]
+[assembly: AssemblyFileVersion("1.7.1")]
 [assembly: ComVisible(false)]

--- a/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
@@ -1,0 +1,22 @@
+﻿namespace TwitchLeecher.Core.Enums
+{
+    public enum VideoQuality
+    {
+        [System.ComponentModel.Description("Source")] Source,
+        [System.ComponentModel.Description("1440p60")] q1440f60,
+        [System.ComponentModel.Description("1440p30")] q1440f30,
+        [System.ComponentModel.Description("1080p60")] q1080f60,
+        [System.ComponentModel.Description("1080p30")] q1080f30,
+        [System.ComponentModel.Description("900p60")] q900f60,
+        [System.ComponentModel.Description("900p30")] q900f30,
+        [System.ComponentModel.Description("720p60")] q720f60,
+        [System.ComponentModel.Description("720p30")] q720f30,
+        //[System.ComponentModel.Description("480p60")] q480f60,
+        [System.ComponentModel.Description("480p30")] q480f30,
+        //[System.ComponentModel.Description("360p60")] q360f60,
+        [System.ComponentModel.Description("360p30")] q360f30,
+        //[System.ComponentModel.Description("160p60")] q160p60,
+        [System.ComponentModel.Description("160p30")] q160f30,
+        [System.ComponentModel.Description("Audio only")] AudioOnly
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
@@ -2,6 +2,8 @@
 {
     public static class FilenameWildcards
     {
+        public delegate bool IsFileNameUsedsDelegate(string fileName);
+
         public static string CHANNEL = "{channel}";
 
         public static string GAME = "{game}";
@@ -11,6 +13,12 @@
         public static string TIME = "{time}";
 
         public static string TIME24 = "{time24}";
+
+        public static string DATE_ = "{date-}";
+
+        public static string TIME_ = "{time-}";
+
+        public static string TIME24_ = "{time24-}";
 
         public static string TITLE = "{title}";
 
@@ -23,5 +31,7 @@
         public static string START = "{start}";
 
         public static string END = "{end}";
+
+        public static string UNIQNUMBER = "{unumber}";
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
@@ -37,11 +37,17 @@ namespace TwitchLeecher.Core.Models
 
         private string _downloadFileName;
 
+        private VideoQuality _downloadQuality;
+        
         private bool _downloadSubfoldersForFav;
 
         private bool _downloadRemoveCompleted;
 
         private bool _downloadDisableConversion;
+
+        private bool _downloadSplitUse;
+
+        private TimeSpan _downloadSplitTime;
 
         private bool _miscUseExternalPlayer;
 
@@ -233,6 +239,18 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
+        public VideoQuality DownloadQuality
+        {
+            get
+            {
+                return _downloadQuality;
+            }
+            set
+            {
+                SetProperty(ref _downloadQuality, value);
+            }
+        }
+
         public bool DownloadSubfoldersForFav
         {
             get
@@ -266,6 +284,30 @@ namespace TwitchLeecher.Core.Models
             set
             {
                 SetProperty(ref _downloadDisableConversion, value);
+            }
+        }
+
+        public bool DownloadSplitUse
+        {
+            get
+            {
+                return _downloadSplitUse;
+            }
+            set
+            {
+                SetProperty(ref _downloadSplitUse, value);
+            }
+        }
+
+        public TimeSpan DownloadSplitTime
+        {
+            get
+            {
+                return _downloadSplitTime;
+            }
+            set
+            {
+                SetProperty(ref _downloadSplitTime, value);
             }
         }
 
@@ -363,6 +405,16 @@ namespace TwitchLeecher.Core.Models
                     AddError(currentProperty, $"Filename contains invalid characters ({invalidChars}.)!");
                 }
             }
+
+            currentProperty = nameof(DownloadSplitTime);
+
+            if (string.IsNullOrWhiteSpace(propertyName) || propertyName == currentProperty)
+            {
+                if (_downloadSplitUse == true && _downloadSplitTime.TotalSeconds < 60)
+                {
+                    AddError(currentProperty, "Split time has to be equal or more 1 minute!");
+                }
+            }
         }
 
         public Preferences Clone()
@@ -382,15 +434,34 @@ namespace TwitchLeecher.Core.Models
                 SearchOnStartup = SearchOnStartup,
                 DownloadTempFolder = DownloadTempFolder,
                 DownloadFolder = DownloadFolder,
+                DownloadQuality = DownloadQuality,
                 DownloadFileName = DownloadFileName,
                 DownloadSubfoldersForFav = DownloadSubfoldersForFav,
                 DownloadRemoveCompleted = DownloadRemoveCompleted,
-                DownloadDisableConversion = DownloadDisableConversion
+                DownloadDisableConversion = DownloadDisableConversion,
+                DownloadSplitUse = DownloadSplitUse,
+                DownloadSplitTime = DownloadSplitTime
             };
 
             clone.SearchFavouriteChannels.AddRange(SearchFavouriteChannels);
 
             return clone;
+        }
+
+        public int GetBestFps()
+        {
+            if (_downloadQuality == VideoQuality.Source)
+                return int.MaxValue;
+            else
+                return int.Parse(_downloadQuality.ToString().Substring(_downloadQuality.ToString().IndexOf("f") + 1));
+        }
+
+        public int GetBestResolution()
+        {
+            if (_downloadQuality == VideoQuality.Source)
+                return int.MaxValue;
+            else
+                return int.Parse(_downloadQuality.ToString().Substring(1, _downloadQuality.ToString().IndexOf("f") - 1));
         }
 
         #endregion Methods

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
@@ -43,6 +43,8 @@ namespace TwitchLeecher.Core.Models
 
         public string Resolution { get; private set; }
 
+        public int? ResolutionY { get; private set; }
+
         public int? Fps { get; private set; }
 
         #endregion Properties
@@ -53,7 +55,9 @@ namespace TwitchLeecher.Core.Models
         {
             QualityId = qualityId;
             QualityString = GetQualityString(qualityId);
-            Resolution = GetResolution(qualityId, resolution);
+            int? _resolutionY = null;
+            Resolution = GetResolution(qualityId, resolution, out _resolutionY);
+            ResolutionY = _resolutionY;
             Fps = GetFps(qualityId, fps);
 
             if (qualityId == QUALITY_AUDIO)
@@ -117,8 +121,9 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        private string GetResolution(string qualityId, string resolution)
+        private string GetResolution(string qualityId, string resolution, out int? resolutionY)
         {
+            resolutionY = null;
             if (!string.IsNullOrWhiteSpace(resolution))
             {
                 if (resolution.Equals("0x0", StringComparison.OrdinalIgnoreCase))
@@ -126,20 +131,28 @@ namespace TwitchLeecher.Core.Models
                     switch (qualityId)
                     {
                         case QUALITY_HIGH:
+                            resolutionY = 720;
                             return "1280x720";
 
                         case QUALITY_MEDIUM:
+                            resolutionY = 480;
                             return "852x480";
 
                         case QUALITY_LOW:
+                            resolutionY = 360;
                             return "640x360";
 
                         case QUALITY_MOBILE:
+                            resolutionY = 160;
                             return "284x160";
                     }
                 }
                 else
                 {
+                    //System.Text.RegularExpressions.Regex parseResolition = new System.Text.RegularExpressions.Regex(@"^(?<x>\d+)x(?<y>\d+)$");
+                    var match = System.Text.RegularExpressions.Regex.Match(resolution, @"^(?<x>\d+)x(?<y>\d+)$");
+                    //resolutionX = match.Success ? (int?)int.Parse(match.Groups["x"].Value) : null;
+                    resolutionY = match.Success ? (int?)int.Parse(match.Groups["y"].Value) : null;
                     return resolution;
                 }
             }

--- a/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
+++ b/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Enums\DownloadState.cs" />
     <Compile Include="Enums\LoadLimitType.cs" />
     <Compile Include="Enums\SearchType.cs" />
+    <Compile Include="Enums\VideoQuality.cs" />
     <Compile Include="Enums\VideoType.cs" />
     <Compile Include="Events\DownloadsCountChangedEvent.cs" />
     <Compile Include="Events\IsAuthorizedChangedEvent.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/InverseBooleanToVisibilityConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/InverseBooleanToVisibilityConverter.cs
@@ -31,4 +31,31 @@ namespace TwitchLeecher.Gui.Converters
 
         #endregion IValueConverter Members
     }
+
+    public class NotInverseBooleanToVisibilityConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is bool))
+            {
+                throw new ApplicationException("Value has to be of type '" + typeof(bool).FullName + "'!");
+            }
+
+            return (!(bool)value) ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is Visibility))
+            {
+                throw new ApplicationException("Value has to be of type '" + typeof(bool).FullName + "'!");
+            }
+
+            return !((Visibility)value == Visibility.Visible ? false : true);
+        }
+
+        #endregion IValueConverter Members
+    }
 }

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using TwitchLeecher.Core.Enums;
+
+namespace TwitchLeecher.Gui.Converters
+{
+    public class VideoQualityToTextConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is VideoQuality valueEnum)
+            {
+                return GetDescription(valueEnum);
+            }
+            else if (value is VideoQuality[] valueEnumArray)
+            {
+                string[] resultArray = new string[valueEnumArray.Length];
+                for(int index = 0;index< valueEnumArray.Length;index++)
+                    resultArray[index] = GetDescription(valueEnumArray[index]);
+                return resultArray;
+            }
+            else
+            { 
+                throw new ApplicationException("Value has to be of type '" + typeof(VideoQuality).FullName + "'!");
+            }
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            VideoQuality[] allValues = (VideoQuality[])Enum.GetValues(typeof(VideoQuality));
+            foreach (VideoQuality enumVal in allValues)
+                if (GetDescription(enumVal).Equals(value))
+                    return enumVal;
+            return VideoQuality.Source;
+            //throw new NotSupportedException("This converter can only convert!");
+        }
+
+        private static string GetDescription(Enum value)
+        {
+            Type type = value.GetType();
+            string Name = Enum.GetName(type, value);
+            if (Name != null)
+            {
+                System.Reflection.FieldInfo field = type.GetField(Name);
+                if (field != null)
+                {
+                    if (Attribute.GetCustomAttribute(field, typeof(System.ComponentModel.DescriptionAttribute)) is System.ComponentModel.DescriptionAttribute attr)
+                    {
+                        return attr.Description;
+                    }
+                }
+            }
+            return value.ToString();
+        }
+
+        #endregion IValueConverter Members
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
+++ b/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Converters\InverseBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\SearchTypeToBooleanConverter.cs" />
     <Compile Include="Converters\LoadLimitToBooleanConverter.cs" />
+    <Compile Include="Converters\VideoQualityToTextConverter.cs" />
     <Compile Include="Events\ShowViewEvent.cs" />
     <Compile Include="Extensions\Icon.cs" />
     <Compile Include="Interfaces\IDonationService.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
@@ -188,6 +188,57 @@ namespace TwitchLeecher.Gui.ViewModels
             }
         }
 
+        public int DownloadSplitTimeHours
+        {
+            get
+            {
+                return (int)CurrentPreferences.DownloadSplitTime.TotalHours;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan(value, current.Minutes, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeMinutes
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Minutes;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int)CurrentPreferences.DownloadSplitTime.TotalHours, value, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeSeconds
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Seconds;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int)CurrentPreferences.DownloadSplitTime.TotalHours, current.Minutes, value);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
         #endregion Properties
 
         #region Methods
@@ -432,6 +483,14 @@ namespace TwitchLeecher.Gui.ViewModels
                 if (CurrentPreferences.HasErrors)
                 {
                     AddError(currentProperty, "Invalid Preferences!");
+
+                    if (CurrentPreferences.GetErrors(nameof(CurrentPreferences.DownloadSplitTime)) is List<string> downloadSplitTimeErrors && downloadSplitTimeErrors.Count > 0)
+                    {
+                        string firstError = downloadSplitTimeErrors.First();
+                        AddError(nameof(DownloadSplitTimeHours), firstError);
+                        AddError(nameof(DownloadSplitTimeMinutes), firstError);
+                        AddError(nameof(DownloadSplitTimeSeconds), firstError);
+                    }
                 }
             }
         }

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
@@ -14,6 +14,7 @@
                 <ResourceDictionary>
                     <converters:InverseBooleanConverter x:Key="InverseBoolConverter" />
                     <converters:InverseBooleanToVisibilityConverter x:Key="InverseBVConverter" />
+                    <converters:NotInverseBooleanToVisibilityConverter x:Key="NotInverseBVConverter" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -106,6 +107,9 @@
                         <RowDefinition SharedSizeGroup="g2" />
                         <RowDefinition Height="5" />
                         <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition Height="5" />
+                        <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition SharedSizeGroup="g2" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -122,18 +126,28 @@
                     </Grid.ColumnDefinitions>
 
                     <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding DownloadParams.CropStart}" Content="Start" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" Maximum="99" Loop="False" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" Maximum="99" Loop="False" />
                     <TextBlock Grid.Row="0" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" />
                     <TextBlock Grid.Row="0" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" />
 
                     <CheckBox Grid.Row="2" Grid.Column="0" IsChecked="{Binding  DownloadParams.CropEnd}" Content="End" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" Maximum="99" Loop="False" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" Maximum="99" Loop="False" />
                     <TextBlock Grid.Row="2" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" />
                     <TextBlock Grid.Row="2" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+
+                    <CheckBox Grid.Row="4" Grid.Column="0" IsChecked="{Binding AutoSplitUseExtended}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Row="4" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+                    <TextBlock Grid.Row="4" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+
+                    <TextBlock Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="9" Text="{Binding AutoSplitPartCount, StringFormat='Video parts: {0}', FallbackValue='Video count: 1'}" VerticalAlignment="Center" HorizontalAlignment="Center" 
+                               Visibility="{Binding AutoSplitUseExtended, Converter={StaticResource ResourceKey='NotInverseBVConverter'}}"/>
                 </Grid>
             </Grid>
         </Grid>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
@@ -156,6 +156,8 @@
                                         <RowDefinition SharedSizeGroup="g1" />
                                         <RowDefinition Height="10" />
                                         <RowDefinition SharedSizeGroup="g1" />
+                                        <RowDefinition Height="10" />
+                                        <RowDefinition SharedSizeGroup="g1" />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Column="0" Grid.Row="0" Text="Status:" FontWeight="Bold" />
@@ -169,13 +171,16 @@
                                     <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding DownloadParams.Video.Game}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="4" Text="Length:" FontWeight="Bold" />
-                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.CroppedLengthStr}" />
+                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.VideoLengthStr}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="6" Text="Recorded:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="6" Text="{Binding DownloadParams.Video.RecordedDate, StringFormat=G}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="8" Text="Quality:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="8" Text="{Binding DownloadParams.Quality.DisplayString}" />
+
+                                    <TextBlock Grid.Column="0" Grid.Row="10" Text="File name:" FontWeight="Bold" />
+                                    <TextBlock Grid.Column="2" Grid.Row="10" Text="{Binding DownloadParams.FullPath}" />
                                 </Grid>
                             </Grid>
                             <Border Grid.Row="2" BorderThickness="0,1,0,0" Padding="0,10,0,0" Margin="0,10,0,0">

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
              xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
              xmlns:enums="clr-namespace:TwitchLeecher.Core.Enums;assembly=TwitchLeecher.Core"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -14,6 +15,7 @@
                 <ResourceDictionary Source="../Theme/Images.xaml" />
                 <ResourceDictionary>
                     <converters:VideoTypeToBooleanConverter x:Key="videoTypeToBooleanConverter" />
+                    <converters:VideoQualityToTextConverter x:Key="videoQualityToTextConverter" />
                     <converters:LoadLimitToBooleanConverter x:Key="loadLimitToBooleanConverter" />
                     <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
                 </ResourceDictionary>
@@ -211,7 +213,17 @@
             </Border>
 
             <Grid Grid.Row="5" Margin="15,0,0,0">
+                <Grid.Resources>
+                    <ObjectDataProvider x:Key="dataFromEnum" MethodName="GetValues"
+                            ObjectType="{x:Type System:Enum}">
+                        <ObjectDataProvider.MethodParameters>
+                            <x:Type TypeName="enums:VideoQuality"/>
+                        </ObjectDataProvider.MethodParameters>
+                    </ObjectDataProvider>
+                </Grid.Resources>
                 <Grid.RowDefinitions>
+                    <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
@@ -278,7 +290,7 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <TextBlock Grid.Column="0" Grid.Row="4" Text="Filename Template" VerticalAlignment="Center" />
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Filename Template" VerticalAlignment="Center" />
                 <TextBox Grid.Row="4" Grid.Column="2" Text="{Binding CurrentPreferences.DownloadFileName, UpdateSourceTrigger=PropertyChanged}" VerticalAlignment="Center" />
                 <fa:ImageAwesome Grid.Row="4" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
@@ -290,6 +302,14 @@
                                 </TextBlock>
                                 <Grid Margin="0,5,0,0">
                                     <Grid.RowDefinitions>
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
                                         <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
@@ -338,45 +358,76 @@
                                     <TextBlock Grid.Row="6" Grid.Column="2" Text="Recording date (yyyyMMdd)" />
                                     <TextBlock Grid.Row="6" Grid.Column="4" Text="20160418" />
 
-                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{time}" />
-                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording time" />
-                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="034622PM" />
+                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{date-}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording date (yyyy-MM-dd)" />
+                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="2016-04-18" />
 
-                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time24}" />
-                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time (24 hours)" />
-                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="174622" />
+                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time}" />
+                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="034622PM" />
 
-                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{id}" />
-                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Twitch video ID" />
-                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="54869708" />
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{time-}" />
+                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="03-46-22_PM" />
+                                    
+                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{time24}" />
+                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="174622" />
 
-                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{title}" />
-                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Video Title" />
-                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="Best Strim Evr!!!" />
+                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{time24-}" />
+                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="17-46-22" />
 
-                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{res}" />
-                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Video Resolution" />
-                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="1280x720" />
+                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{id}" />
+                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Twitch video ID" />
+                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="54869708" />
 
-                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{fps}" />
-                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Video Framerate" />
-                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="60" />
+                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{title}" />
+                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Video Title" />
+                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="Best Strim Evr!!!" />
 
-                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{start}" />
-                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Crop start time (HHmmss)" />
-                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="012744" />
+                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{res}" />
+                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Video Resolution" />
+                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="1280x720" />
 
-                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{end}" />
-                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Crop end time (HHmmss)" />
-                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="025317" />
+                                    <TextBlock Grid.Row="24" Grid.Column="0" Text="{}{fps}" />
+                                    <TextBlock Grid.Row="24" Grid.Column="2" Text="Video Framerate" />
+                                    <TextBlock Grid.Row="24" Grid.Column="4" Text="60" />
+
+                                    <TextBlock Grid.Row="26" Grid.Column="0" Text="{}{start}" />
+                                    <TextBlock Grid.Row="26" Grid.Column="2" Text="Crop start time (HHmmss)" />     
+                                    <TextBlock Grid.Row="26" Grid.Column="4" Text="012744" />
+
+                                    <TextBlock Grid.Row="28" Grid.Column="0" Text="{}{end}" />
+                                    <TextBlock Grid.Row="28" Grid.Column="2" Text="Crop end time (HHmmss)" />
+                                    <TextBlock Grid.Row="28" Grid.Column="4" Text="025317" />
+
+                                    <TextBlock Grid.Row="30" Grid.Column="0" Text="{}{unumber}" />
+                                    <TextBlock Grid.Row="30" Grid.Column="2" Text="Number to avoid overwrite" />
+                                    <TextBlock Grid.Row="30" Grid.Column="4" Text="1" />
                                 </Grid>
                             </StackPanel>
                         </ToolTip>
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="6" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="Quality by default" VerticalAlignment="Center" />
+                <ComboBox Grid.Row="6" Grid.Column="2" VerticalAlignment="Center" ItemsSource="{Binding Source={StaticResource dataFromEnum}, Converter={StaticResource videoQualityToTextConverter}}" SelectedItem="{Binding CurrentPreferences.DownloadQuality, Converter={StaticResource videoQualityToTextConverter}}"/>
                 <fa:ImageAwesome Grid.Row="6" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip  Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Quality by default" />
+                                <TextBlock TextAlignment="Justify">
+                                    Stream quality that will be select for download by default. If there are no this quality, will be select the nearest resolution.
+                                </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+                
+                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -389,8 +440,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -403,8 +454,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="12" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="12" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -427,6 +478,8 @@
 
             <Grid Grid.Row="7" Margin="15,0,0,0">
                 <Grid.RowDefinitions>
+                    <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
@@ -476,6 +529,42 @@
                                 <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Video Player" />
                                 <TextBlock TextAlignment="Justify">
                                         The external video player to use (preferably VLC because it works great with Twitch streams)
+                                </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Auto Split" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <Grid Grid.Row="4" Grid.Column="2" Grid.IsSharedSizeScope="True">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" IsChecked="{Binding CurrentPreferences.DownloadSplitUse}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                    <TextBlock Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                </Grid>
+                <fa:ImageAwesome Grid.Row="4" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Auto Split" />
+                                <TextBlock TextAlignment="Justify">
+                                        Auto split stream in part with this length
                                 </TextBlock>
                             </StackPanel>
                         </ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
@@ -5,7 +5,7 @@ namespace TwitchLeecher.Services.Interfaces
 {
     public interface IFilenameService
     {
-        string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
+        string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
 
         string SubstituteInvalidChars(string filename, string replaceStr);
 

--- a/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
@@ -12,7 +12,7 @@ namespace TwitchLeecher.Services.Services
     {
         #region Methods
 
-        public string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
+        public string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
         {
             if (video == null)
             {
@@ -37,6 +37,9 @@ namespace TwitchLeecher.Services.Services
             result = result.Replace(FilenameWildcards.DATE, recorded.ToString("yyyyMMdd"));
             result = result.Replace(FilenameWildcards.TIME, recorded.ToString("hhmmsstt", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.TIME24, recorded.ToString("HHmmss", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.DATE_, recorded.ToString("yyyy-MM-dd"));
+            result = result.Replace(FilenameWildcards.TIME_, recorded.ToString("hh-mm-ss_tt", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.TIME24_, recorded.ToString("HH-mm-ss", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.ID, video.Id);
             result = result.Replace(FilenameWildcards.TITLE, video.Title);
             result = result.Replace(FilenameWildcards.RES, !string.IsNullOrWhiteSpace(selectedQuality.Resolution) ? selectedQuality.Resolution : TwitchVideoQuality.UNKNOWN);
@@ -46,6 +49,14 @@ namespace TwitchLeecher.Services.Services
 
             result = SubstituteInvalidChars(result, "_");
 
+            if (result.Contains(FilenameWildcards.UNIQNUMBER))
+            {
+                int index = 1;
+                while (File.Exists(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))) || IsFileNameUsed(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))))
+                    index++;
+                result = result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString());
+            }
+            
             return result;
         }
 

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -39,11 +39,14 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_EL = "Download";
         private const string DOWNLOAD_TEMPFOLDER_EL = "TempFolder";
         private const string DOWNLOAD_FOLDER_EL = "Folder";
+        private const string DOWNLOAD_QUALITY_EL = "Quality";
         private const string DOWNLOAD_FILENAME_EL = "FileName";
         private const string DOWNLOAD_SUBFOLDERSFORFAV_EL = "SubfoldersForFav";
         private const string DOWNLOAD_REMOVECOMPLETED_EL = "RemoveCompleted";
         private const string DOWNLOAD_DISABLECONVERSION_EL = "DisableConversion";
-
+        private const string DOWNLOAD_SPLITEUSE_EL = "SplitUse";
+        private const string DOWNLOAD_SPLITETIME_EL = "SplitTime";
+        
         private const string MISC_EL = "Misc";
         private const string MISC_USEEXTERNALPLAYER_EL = "UseExternalPlayer";
         private const string MISC_EXTERNALPLAYER_EL = "ExternalPlayer";
@@ -201,6 +204,10 @@ namespace TwitchLeecher.Services.Services
                     downloadEl.Add(downloadFolderEl);
                 }
 
+                XElement downloadQualityEl = new XElement(DOWNLOAD_QUALITY_EL);
+                downloadQualityEl.SetValue(preferences.DownloadQuality);
+                downloadEl.Add(downloadQualityEl);
+
                 if (!string.IsNullOrWhiteSpace(preferences.DownloadFileName))
                 {
                     XElement downloadFileNameEl = new XElement(DOWNLOAD_FILENAME_EL);
@@ -219,6 +226,14 @@ namespace TwitchLeecher.Services.Services
                 XElement downloadDisableConversionEl = new XElement(DOWNLOAD_DISABLECONVERSION_EL);
                 downloadDisableConversionEl.SetValue(preferences.DownloadDisableConversion);
                 downloadEl.Add(downloadDisableConversionEl);
+
+                XElement downloadSplitUseEl = new XElement(DOWNLOAD_SPLITEUSE_EL);
+                downloadSplitUseEl.SetValue(preferences.DownloadSplitUse);
+                downloadEl.Add(downloadSplitUseEl);
+
+                XElement downloadSplitTimeEl = new XElement(DOWNLOAD_SPLITETIME_EL);
+                downloadSplitTimeEl.SetValue(DateTime.MinValue + preferences.DownloadSplitTime);
+                downloadEl.Add(downloadSplitTimeEl);
 
                 // Miscellanious
                 XElement miscUseExternalPlayerEl = new XElement(MISC_USEEXTERNALPLAYER_EL);
@@ -451,6 +466,20 @@ namespace TwitchLeecher.Services.Services
                                 }
                             }
 
+                            XElement downloadQualityEl = downloadEl.Element(DOWNLOAD_QUALITY_EL);
+
+                            if (downloadQualityEl != null)
+                            {
+                                try
+                                {
+                                    preferences.DownloadQuality = downloadQualityEl.GetValueAsEnum<VideoQuality>();
+                                }
+                                catch
+                                {
+                                    // Value from config file could not be loaded, use default value
+                                }
+                            }
+
                             XElement downloadFileNameEl = downloadEl.Element(DOWNLOAD_FILENAME_EL);
 
                             if (downloadFileNameEl != null)
@@ -513,6 +542,34 @@ namespace TwitchLeecher.Services.Services
                                     // Value from config file could not be loaded, use default value
                                 }
                             }
+
+                            XElement downloadSplitUseEl = downloadEl.Element(DOWNLOAD_SPLITEUSE_EL);
+
+                            if (downloadSplitUseEl != null)
+                            {
+                                try
+                                {
+                                    preferences.DownloadSplitUse = downloadSplitUseEl.GetValueAsBool();
+                                }
+                                catch
+                                {
+                                    // Value from config file could not be loaded, use default value
+                                }
+                            }
+
+                            XElement downloadSplitTimeEl = downloadEl.Element(DOWNLOAD_SPLITETIME_EL);
+
+                            if (downloadSplitTimeEl != null)
+                            {
+                                try
+                                {
+                                    preferences.DownloadSplitTime = downloadSplitTimeEl.GetValueAsDateTime() - DateTime.MinValue;
+                                }
+                                catch
+                                {
+                                    // Value from config file could not be loaded, use default value
+                                }
+                            }
                         }
 
                         XElement miscEl = preferencesEl.Element(MISC_EL);
@@ -569,6 +626,7 @@ namespace TwitchLeecher.Services.Services
                 SearchOnStartup = false,
                 DownloadTempFolder = _folderService.GetTempFolder(),
                 DownloadFolder = _folderService.GetDownloadFolder(),
+                DownloadQuality = VideoQuality.Source,
                 DownloadFileName = FilenameWildcards.DATE + "_" + FilenameWildcards.ID + "_" + FilenameWildcards.GAME,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,


### PR DESCRIPTION
Add option for autosplit video (also with special setting 'autosplit by default'), it will split video and add uniq number in {unumber}.
Add 'Prefer quality' setting to not select quality manually if you want not source.
Upgrate name check to avoid case when you start download with some name, but other download with same name was already created (and will rewrite).
Add some more options in name - date and time with hyphen and uniq number for automatically avoid rewriting
Add row with filename in download tab, also edit cropped string to show from and to time.