### PR TITLE
Autosplit, default quality, some wildcards and info in downloads tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project is fork from original version, with some improvement (from my point
 
 I will improve it futher, you can ask any quastion
 
+Below information from original creator - Franiac
+
 ## Is this project alive?????
 
 Yes! Just because there are no commits for a longer period of time, does not mean the project is dead. I am a human being with a life and TL never was an still is not my top priority. I will always try to keep it running if there are breaking changes, but new features can take time. If I dicide to discontinue TL (which is very unlikely) you WILL be informed very clearly.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ If you are looking for an extremely fast and easy to use Twitch VOD downloader, 
 
 ![Twitch Leecher Screenshot](http://www.fakesmilerevolution.com/files/fsr/twitchleecher/tl14.jpg)
 
+# This is fork from Franiac
+
+This project is fork from original version, with some improvement (from my point of view)
+
+I will improve it futher, you can ask any quastion
+
 ## Is this project alive?????
 
 Yes! Just because there are no commits for a longer period of time, does not mean the project is dead. I am a human being with a life and TL never was an still is not my top priority. I will always try to keep it running if there are breaking changes, but new features can take time. If I dicide to discontinue TL (which is very unlikely) you WILL be informed very clearly.
@@ -12,7 +18,7 @@ Yes! Just because there are no commits for a longer period of time, does not mea
 - Requires .NET Framework 4.8
 - Requires Windows 7 SP1 64 Bit or higher
 
-The Installer is available [HERE](https://github.com/Franiac/TwitchLeecher/releases)
+The Installer is available [HERE](https://github.com/Targen92/TwitchLeecher/releases)
 
 Once installed, future releases will automatically update current installations with a single click!
 
@@ -41,7 +47,7 @@ Nearly all of the well known VOD downloaders execute the download process via FF
 **IMPORTANT:** Help me beeing efficient, please! I am developing Twitch Leecher in my free time for no money. Contribute to the project by posting complete, structured and helpful issues which I can reproduce quickly without asking for missing information. When creating a new issue please follow the below checklist:
 
 - Windows Insider Builds are NOT supported!
-- Take a look at the latest closed issues [HERE](https://github.com/Franiac/TwitchLeecher/issues?q=is%3Aissue+is%3Aclosed). Maybe your problem has already been resolved
+- Take a look at the latest closed issues [HERE](https://github.com/Franiac/TwitchLeecher/issues?q=is%3Aissue+is%3Aclosed) or maybe [HERE](https://github.com/Targen92/TwitchLeecher/issues?q=is%3Aissue+is%3Aclosed). Maybe your problem has already been resolved
 - Provide the version of Twitch Leecher you are using
 - Provide as much information about the VOD as possible (Url, Channel, ID)
 - Provide information about your operating system (e.g. Windows 10 64 Bit)
@@ -52,4 +58,4 @@ Nearly all of the well known VOD downloaders execute the download process via FF
 ![Twitch Leecher Log Screenshot](http://www.fakesmilerevolution.com/files/fsr/twitchleecher/tl14log.jpg)
 
 ## LICENSE
-[MIT License](https://github.com/Franiac/TwitchLeecher/blob/master/LICENSE)
+[MIT License](https://github.com/Targen92/TwitchLeecher/blob/master/LICENSE)

--- a/TwitchLeecher/GlobalAssemblyInfo.cs
+++ b/TwitchLeecher/GlobalAssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Franiac")]
 [assembly: AssemblyCopyright("Copyright © 2018 Dominik Rebitzer")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.7.0")]
+[assembly: AssemblyFileVersion("1.7.1")]
 [assembly: ComVisible(false)]

--- a/TwitchLeecher/GlobalAssemblyInfo.cs
+++ b/TwitchLeecher/GlobalAssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyProduct("Twitch Leecher")]
 [assembly: AssemblyDescription("Twitch Broadcast Downloader")]
-[assembly: AssemblyCompany("Franiac")]
+[assembly: AssemblyCompany("Targen92")]
 [assembly: AssemblyCopyright("Copyright © 2018 Dominik Rebitzer")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.7.1")]

--- a/TwitchLeecher/TwitchLeecher.Core/Enums/DownloadState.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/DownloadState.cs
@@ -5,9 +5,8 @@
         Queued,
         Paused,
         Downloading,
-        WaitConcatenation,
+        Waiting,
         Concatenation,
-        Converting,
         Canceled,
         Error,
         Done

--- a/TwitchLeecher/TwitchLeecher.Core/Enums/DownloadState.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/DownloadState.cs
@@ -5,6 +5,9 @@
         Queued,
         Paused,
         Downloading,
+        WaitConcatenation,
+        Concatenation,
+        Converting,
         Canceled,
         Error,
         Done

--- a/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace TwitchLeecher.Core.Enums
+{
+    public enum VideoQuality
+    {
+        [Description("Source"), Descriptor(fps: -1, resolutionY: -1)] Source,
+        [Description("1440p60"), Descriptor(fps: 60, resolutionY: 1440)] q1440f60,
+        [Description("1440p30"), Descriptor(fps: 30, resolutionY: 1440)] q1440f30,
+        [Description("1080p60"), Descriptor(fps: 60, resolutionY: 1080)] q1080f60,
+        [Description("1080p30"), Descriptor(fps: 30, resolutionY: 1080)] q1080f30,
+        [Description("900p60"), Descriptor(fps: 60, resolutionY: 900)] q900f60,
+        [Description("900p30"), Descriptor(fps: 30, resolutionY: 900)] q900f30,
+        [Description("720p60"), Descriptor(fps: 60, resolutionY: 720)] q720f60,
+        [Description("720p30"), Descriptor(fps: 30, resolutionY: 720)] q720f30,
+        //[Description("480p60"), Descriptor(fps: 60, resolutionY: 480)] q480f60,
+        [Description("480p30"), Descriptor(fps: 30, resolutionY: 480)] q480f30,
+        //[Description("360p60"), Descriptor(fps: 60, resolutionY: 360)] q360f60,
+        [Description("360p30"), Descriptor(fps: 30, resolutionY: 360)] q360f30,
+        //[Description("160p60"), Descriptor(fps: 60, resolutionY: 160)] q160p60,
+        [Description("160p30"), Descriptor(fps: 30, resolutionY: 160)] q160f30,
+        [Description("Audio only"), Descriptor(fps: 0, resolutionY: 0)] AudioOnly
+    }
+
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class DescriptorAttribute : Attribute
+    {
+        public int FPS { get; }
+        public int ResolutionY { get; }
+
+        public DescriptorAttribute(int fps, int resolutionY)
+        {
+            FPS = fps;
+            ResolutionY = resolutionY;
+        }
+    }
+
+    public static partial class GlobalMethods
+    {
+        public static int GetFps(this VideoQuality item)
+        {
+            Type type = item.GetType();
+            string itemName = Enum.GetName(type, item);
+            if (itemName != null)
+            {
+                System.Reflection.FieldInfo itemField = type.GetField(itemName);
+                if (itemField != null)
+                {
+                    if (Attribute.GetCustomAttribute(itemField, typeof(DescriptorAttribute)) is DescriptorAttribute attr)
+                    {
+                        return attr.FPS;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        public static int GetResolutionY(this VideoQuality item)
+        {
+            Type type = item.GetType();
+            string itemName = Enum.GetName(type, item);
+            if (itemName != null)
+            {
+                System.Reflection.FieldInfo itemField = type.GetField(itemName);
+                if (itemField != null)
+                {
+                    if (Attribute.GetCustomAttribute(itemField, typeof(DescriptorAttribute)) is DescriptorAttribute attr)
+                    {
+                        return attr.ResolutionY;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        public static string GetDescription(this VideoQuality value)
+        {
+            Type type = value.GetType();
+            string Name = Enum.GetName(type, value);
+            if (Name != null)
+            {
+                System.Reflection.FieldInfo field = type.GetField(Name);
+                if (field != null)
+                {
+                    if (Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) is DescriptionAttribute attr)
+                    {
+                        return attr.Description;
+                    }
+                }
+            }
+            return value.ToString();
+        }
+
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -24,6 +24,7 @@ namespace TwitchLeecher.Core.Models
 
         private bool _cropStart;
         private bool _cropEnd;
+        private bool _streamingNow;
         private bool _disableConversion;
 
         private TimeSpan _cropStartTime;
@@ -209,11 +210,15 @@ namespace TwitchLeecher.Core.Models
         {
             get
             {
-                return _cropEnd;
+                return _cropEnd && !_streamingNow;
             }
             set
             {
                 SetProperty(ref _cropEnd, value, nameof(CropEnd));
+                if (_cropEnd && _streamingNow)
+                {
+                    SetProperty(ref _streamingNow, false, nameof(StreamingNow));
+                }
                 FirePropertyChanged(nameof(CroppedLength));
             }
         }
@@ -228,6 +233,7 @@ namespace TwitchLeecher.Core.Models
             {
                 SetProperty(ref _cropEndTime, value, nameof(CropEndTime));
                 FirePropertyChanged(nameof(CroppedLength));
+                FirePropertyChanged(nameof(VideoLengthStr));
             }
         }
 
@@ -262,6 +268,20 @@ namespace TwitchLeecher.Core.Models
                     return $"{CroppedLength.ToDaylessString()} ({(_cropStart ? _cropStartTime.ToDaylessString() : "00:00:00")} - {(_cropEnd ? _cropEndTime.ToDaylessString() : Video.Length.ToDaylessString())})";
                 else
                     return CroppedLength.ToDaylessString();
+            }
+        }
+
+        public bool StreamingNow
+        {
+            get
+            {
+                return _streamingNow;
+            }
+            set
+            {
+                SetProperty(ref _streamingNow, value, nameof(StreamingNow));
+                FirePropertyChanged(nameof(CropEnd));
+                FirePropertyChanged(nameof(CroppedLength));
             }
         }
 
@@ -338,7 +358,7 @@ namespace TwitchLeecher.Core.Models
 
             if (string.IsNullOrWhiteSpace(propertyName) || propertyName == currentProperty)
             {
-                if (_cropEnd)
+                if (_cropEnd && !_streamingNow)
                 {
                     TimeSpan videoLength = _video.Length;
 
@@ -354,6 +374,15 @@ namespace TwitchLeecher.Core.Models
                     {
                         AddError(currentProperty, "The cropped video has to be at least 5s long!");
                     }
+                }
+            }
+
+            currentProperty = nameof(StreamingNow);
+
+            if (string.IsNullOrWhiteSpace(propertyName) || propertyName == currentProperty)
+            {
+                if (_streamingNow)
+                {
                 }
             }
 

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -42,9 +42,11 @@ namespace TwitchLeecher.Core.Models
             }
 
             _video = video ?? throw new ArgumentNullException(nameof(video));
-            _quality = quality ?? throw new ArgumentNullException(nameof(quality));
             _vodAuthInfo = vodAuthInfo ?? throw new ArgumentNullException(nameof(vodAuthInfo));
 
+            //null mean that user should manually select quality. Don't worry, validation check will mark this issue
+            _quality = quality;// ?? throw new ArgumentNullException(nameof(quality));
+            
             _folder = folder;
             _filename = filename;
             _disableConversion = disableConversion;

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -205,11 +205,14 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        public string CroppedLengthStr
+        public string VideoLengthStr
         {
             get
             {
-                return CroppedLength.ToDaylessString();
+                if (_cropStart || _cropEnd)
+                    return $"{CroppedLength.ToDaylessString()} ({(_cropStart ? _cropStartTime.ToDaylessString() : "00:00:00")} - {(_cropEnd ? _cropEndTime.ToDaylessString() : Video.Length.ToDaylessString())})";
+                else
+                    return CroppedLength.ToDaylessString();
             }
         }
 

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadTask.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadTask.cs
@@ -6,16 +6,13 @@ namespace TwitchLeecher.Core.Models
 {
     public class DownloadTask
     {
-        public DownloadTask(Task task, Task continueTask, CancellationTokenSource cancellationTokenSource)
+        public DownloadTask(CancellationTokenSource cancellationTokenSource, params Task[] tasks)
         {
-            Task = task ?? throw new ArgumentNullException(nameof(task));
-            ContinueTask = continueTask ?? throw new ArgumentNullException(nameof(continueTask));
+            Tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
             CancellationTokenSource = cancellationTokenSource ?? throw new ArgumentNullException(nameof(cancellationTokenSource));
         }
 
-        public Task Task { get; private set; }
-
-        public Task ContinueTask { get; private set; }
+        public Task[] Tasks { get; private set; }
 
         public CancellationTokenSource CancellationTokenSource { get; private set; }
     }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
@@ -12,6 +12,12 @@
 
         public static string TIME24 = "{time24}";
 
+        public static string DATE_ = "{date-}";
+
+        public static string TIME_ = "{time-}";
+
+        public static string TIME24_ = "{time24-}";
+
         public static string TITLE = "{title}";
 
         public static string RES = "{res}";

--- a/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
@@ -2,6 +2,8 @@
 {
     public static class FilenameWildcards
     {
+        public delegate bool IsFileNameUsedsDelegate(string fileName);
+
         public static string CHANNEL = "{channel}";
 
         public static string GAME = "{game}";
@@ -29,5 +31,7 @@
         public static string START = "{start}";
 
         public static string END = "{end}";
+
+        public static string UNIQNUMBER = "{unumber}";
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
@@ -54,6 +54,8 @@ namespace TwitchLeecher.Core.Models
 
         private int _splitOverlapSeconds;
 
+        private bool _downloadAndConcatSimultaneously;
+
         private bool _miscUseExternalPlayer;
 
         private string _miscExternalPlayer;
@@ -292,6 +294,18 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
+        public bool DownloadAndConcatSimultaneously
+        {
+            get
+            {
+                return _downloadAndConcatSimultaneously;
+            }
+            set
+            {
+                SetProperty(ref _downloadAndConcatSimultaneously, value);
+            }
+        }
+
         public bool DownloadSplitUse
         {
             get
@@ -482,6 +496,7 @@ namespace TwitchLeecher.Core.Models
                 DownloadSubfoldersForFav = DownloadSubfoldersForFav,
                 DownloadRemoveCompleted = DownloadRemoveCompleted,
                 DownloadDisableConversion = DownloadDisableConversion,
+                DownloadAndConcatSimultaneously = DownloadAndConcatSimultaneously,
                 DownloadSplitUse = DownloadSplitUse,
                 DownloadSplitTime = DownloadSplitTime,
                 SplitOverlapSeconds = SplitOverlapSeconds,

--- a/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
@@ -37,6 +37,8 @@ namespace TwitchLeecher.Core.Models
 
         private string _downloadFileName;
 
+        private VideoQuality _downloadQuality;
+
         private bool _downloadSubfoldersForFav;
 
         private bool _downloadRemoveCompleted;
@@ -233,6 +235,18 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
+        public VideoQuality DownloadQuality
+        {
+            get
+            {
+                return _downloadQuality;
+            }
+            set
+            {
+                SetProperty(ref _downloadQuality, value);
+            }
+        }
+
         public bool DownloadSubfoldersForFav
         {
             get
@@ -383,6 +397,7 @@ namespace TwitchLeecher.Core.Models
                 DownloadTempFolder = DownloadTempFolder,
                 DownloadFolder = DownloadFolder,
                 DownloadFileName = DownloadFileName,
+                DownloadQuality = DownloadQuality,
                 DownloadSubfoldersForFav = DownloadSubfoldersForFav,
                 DownloadRemoveCompleted = DownloadRemoveCompleted,
                 DownloadDisableConversion = DownloadDisableConversion
@@ -392,7 +407,6 @@ namespace TwitchLeecher.Core.Models
 
             return clone;
         }
-
         #endregion Methods
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
@@ -15,6 +15,32 @@ namespace TwitchLeecher.Core.Models
 
         #endregion Constatnts
 
+        #region GlobalMethods
+
+        public static List<Tuple<TimeSpan?, TimeSpan?>> GetListOfSplitTimes(TimeSpan videoLength, TimeSpan? startCrop, TimeSpan? endCrop, TimeSpan splitTime, int overlapSec)
+        {
+            endCrop = endCrop ?? videoLength;
+            List<Tuple<TimeSpan?, TimeSpan?>> result = new List<Tuple<TimeSpan?, TimeSpan?>>();
+
+            TimeSpan? curStart = startCrop;// ?? TimeSpan.Zero;
+            TimeSpan curEnd = (curStart ?? TimeSpan.Zero).Add(splitTime.Add(new TimeSpan(0, 0, overlapSec)));
+            while (curEnd < endCrop.Value)
+            {
+                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, curEnd));
+                curStart = curEnd.Add(new TimeSpan(0, 0, -overlapSec));
+                curEnd = curEnd.Add(splitTime);
+            }
+            if (endCrop.Value.TotalSeconds - (curStart?.TotalSeconds ?? 0) < Preferences.MinSplitLength && result.Count > 0)
+            {//Add remaining seconds to last part
+                result[result.Count - 1] = new Tuple<TimeSpan?, TimeSpan?>(result[result.Count - 1].Item1, endCrop == videoLength ? null : endCrop);
+            }
+            else//or add new last part
+                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, endCrop == videoLength ? null : endCrop));
+            return result;
+        }
+
+        #endregion GlobalMethods
+
         #region Fields
 
         private TimeSpan _length;

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using TwitchLeecher.Shared.Extensions;
+using TwitchLeecher.Shared.Notification;
 
 namespace TwitchLeecher.Core.Models
 {
-    public class TwitchVideo
+    public class TwitchVideo : BindableBase
     {
         #region Constatnts
 
@@ -13,6 +14,12 @@ namespace TwitchLeecher.Core.Models
         private const string UNKNOWN_GAME = "Unknown";
 
         #endregion Constatnts
+
+        #region Fields
+
+        private TimeSpan _length;
+
+        #endregion Fields
 
         #region Constructors
 
@@ -53,7 +60,7 @@ namespace TwitchLeecher.Core.Models
             }
 
             Views = views;
-            Length = length;
+            _length = length;
             Qualities = qualities;
             RecordedDate = recordedDate;
             Thumbnail = thumbnail ?? throw new ArgumentNullException(nameof(thumbnail));
@@ -73,7 +80,18 @@ namespace TwitchLeecher.Core.Models
 
         public string Game { get; }
 
-        public TimeSpan Length { get; }
+        public TimeSpan Length
+        {
+            get
+            {
+                return _length;
+            }
+            set
+            {
+                SetProperty(ref _length, value, nameof(Length));
+                FirePropertyChanged(nameof(LengthStr));
+            }
+        }
 
         public string LengthStr
         {

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoDownload.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoDownload.cs
@@ -100,12 +100,12 @@ namespace TwitchLeecher.Core.Models
         {
             get
             {
-                if (_downloadState != DownloadState.Downloading)
+                if (_downloadState == DownloadState.Downloading || _downloadState == DownloadState.Waiting || _downloadState == DownloadState.Concatenation)
                 {
-                    return _downloadState.ToString();
+                    return _status;
                 }
 
-                return _status;
+                return _downloadState.ToString();
             }
             private set
             {

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
@@ -43,6 +43,8 @@ namespace TwitchLeecher.Core.Models
 
         public string Resolution { get; private set; }
 
+        public int? ResolutionY { get; private set; }
+
         public int? Fps { get; private set; }
 
         #endregion Properties
@@ -53,7 +55,8 @@ namespace TwitchLeecher.Core.Models
         {
             QualityId = qualityId;
             QualityString = GetQualityString(qualityId);
-            Resolution = GetResolution(qualityId, resolution);
+            Resolution = GetResolution(qualityId, resolution, out int? _resolutionY);
+            ResolutionY = _resolutionY;
             Fps = GetFps(qualityId, fps);
 
             if (qualityId == QUALITY_AUDIO)
@@ -90,7 +93,7 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        public string GetQualityString(string qualityId)
+        static public string GetQualityString(string qualityId)
         {
             switch (qualityId)
             {
@@ -117,8 +120,9 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        private string GetResolution(string qualityId, string resolution)
+        private string GetResolution(string qualityId, string resolution, out int? resolutionY)
         {
+            resolutionY = null;
             if (!string.IsNullOrWhiteSpace(resolution))
             {
                 if (resolution.Equals("0x0", StringComparison.OrdinalIgnoreCase))
@@ -126,20 +130,28 @@ namespace TwitchLeecher.Core.Models
                     switch (qualityId)
                     {
                         case QUALITY_HIGH:
+                            resolutionY = 720;
                             return "1280x720";
 
                         case QUALITY_MEDIUM:
+                            resolutionY = 480;
                             return "852x480";
 
                         case QUALITY_LOW:
+                            resolutionY = 360;
                             return "640x360";
 
                         case QUALITY_MOBILE:
+                            resolutionY = 160;
                             return "284x160";
                     }
                 }
                 else
                 {
+                    //System.Text.RegularExpressions.Regex parseResolition = new System.Text.RegularExpressions.Regex(@"^(?<x>\d+)x(?<y>\d+)$");
+                    var match = System.Text.RegularExpressions.Regex.Match(resolution, @"^(?<x>\d+)x(?<y>\d+)$");
+                    //resolutionX = match.Success ? (int?)int.Parse(match.Groups["x"].Value) : null;
+                    resolutionY = match.Success ? (int?)int.Parse(match.Groups["y"].Value) : null;
                     return resolution;
                 }
             }

--- a/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
+++ b/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Enums\DownloadState.cs" />
     <Compile Include="Enums\LoadLimitType.cs" />
     <Compile Include="Enums\SearchType.cs" />
+    <Compile Include="Enums\VideoQuality.cs" />
     <Compile Include="Enums\VideoType.cs" />
     <Compile Include="Events\DownloadsCountChangedEvent.cs" />
     <Compile Include="Events\IsAuthorizedChangedEvent.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/DownloadStateToColorConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/DownloadStateToColorConverter.cs
@@ -30,7 +30,7 @@ namespace TwitchLeecher.Gui.Converters
                 case DownloadState.Canceled:
                     return (Color)ColorConverter.ConvertFromString("#FFFF1900");
 
-                case DownloadState.WaitConcatenation:
+                case DownloadState.Waiting:
                     return (Color)ColorConverter.ConvertFromString("#FFE1CD00");
                     
                 default:

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/DownloadStateToColorConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/DownloadStateToColorConverter.cs
@@ -30,6 +30,9 @@ namespace TwitchLeecher.Gui.Converters
                 case DownloadState.Canceled:
                     return (Color)ColorConverter.ConvertFromString("#FFFF1900");
 
+                case DownloadState.WaitConcatenation:
+                    return (Color)ColorConverter.ConvertFromString("#FFE1CD00");
+                    
                 default:
                     return (Color)ColorConverter.ConvertFromString("#FF03C600");
             }

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using TwitchLeecher.Core.Enums;
+
+namespace TwitchLeecher.Gui.Converters
+{
+    public class VideoQualityToTextConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is VideoQuality valueEnum)
+            {
+                return valueEnum.GetDescription();
+            }
+            else if (value is VideoQuality[] valueEnumArray)
+            {
+                string[] resultArray = new string[valueEnumArray.Length];
+                for(int index = 0;index< valueEnumArray.Length;index++)
+                    resultArray[index] = valueEnumArray[index].GetDescription();
+                return resultArray;
+            }
+            else
+            { 
+                throw new ApplicationException("Value has to be of type '" + typeof(VideoQuality).FullName + "'!");
+            }
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            VideoQuality[] allValues = (VideoQuality[])Enum.GetValues(typeof(VideoQuality));
+            foreach (VideoQuality enumVal in allValues)
+                if (enumVal.GetDescription().Equals(value))
+                    return enumVal;
+            return VideoQuality.Source;
+            //throw new NotSupportedException("This converter can only convert!");
+        }
+        #endregion IValueConverter Members
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
+++ b/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Converters\InverseBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\SearchTypeToBooleanConverter.cs" />
     <Compile Include="Converters\LoadLimitToBooleanConverter.cs" />
+    <Compile Include="Converters\VideoQualityToTextConverter.cs" />
     <Compile Include="Events\ShowViewEvent.cs" />
     <Compile Include="Extensions\Icon.cs" />
     <Compile Include="Interfaces\IDonationService.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
@@ -418,12 +418,12 @@ namespace TwitchLeecher.Gui.ViewModels
                 curStart = curEnd.Add(new TimeSpan(0, 0, -overlapSec));
                 curEnd = curEnd.Add(splitTime);
             }
-            if (endCrop.Value.TotalSeconds - (curStart?.TotalSeconds??0) < Preferences.MinSplitLength && result.Count > 0)
+            if (endCrop.Value.TotalSeconds - (curStart?.TotalSeconds ?? 0) < Preferences.MinSplitLength && result.Count > 0)
             {//Add remaining seconds to last part
-                result[result.Count - 1] = new Tuple<TimeSpan?, TimeSpan?>(result[result.Count - 1].Item1, null);
+                result[result.Count - 1] = new Tuple<TimeSpan?, TimeSpan?>(result[result.Count - 1].Item1, endCrop == video.Length ? null : endCrop);
             }
             else//or add new last part
-                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, null));
+                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, endCrop == video.Length ? null : endCrop));
             return result;
         }
 

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
@@ -274,13 +274,18 @@ namespace TwitchLeecher.Gui.ViewModels
         private void UpdateFilenameFromTemplate()
         {
             Preferences currentPrefs = _preferencesService.CurrentPreferences.Clone();
+            string folder = currentPrefs.DownloadFolder;
+            string fileName = currentPrefs.DownloadFileName;
 
             TimeSpan? cropStartTime = _downloadParams.CropStart ? _downloadParams.CropStartTime : TimeSpan.Zero;
             TimeSpan? cropEndTime = _downloadParams.CropEnd ? _downloadParams.CropEndTime : _downloadParams.Video.Length;
 
-            string fileName = _filenameService.SubstituteWildcards(currentPrefs.DownloadFileName, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
             fileName = _filenameService.EnsureExtension(fileName, currentPrefs.DownloadDisableConversion);
 
+            fileName = _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
+
+            _downloadParams.Filename = fileName;
+            
             _downloadParams.Filename = fileName;
         }
 

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
@@ -188,6 +188,56 @@ namespace TwitchLeecher.Gui.ViewModels
             }
         }
 
+        public int DownloadSplitTimeHours
+        {
+            get
+            {
+                return (int) CurrentPreferences.DownloadSplitTime.TotalHours;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan(value, current.Minutes, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeMinutes
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Minutes;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int) CurrentPreferences.DownloadSplitTime.TotalHours, value, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeSeconds
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Seconds;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int) CurrentPreferences.DownloadSplitTime.TotalHours, current.Minutes, value);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
         #endregion Properties
 
         #region Methods
@@ -432,6 +482,14 @@ namespace TwitchLeecher.Gui.ViewModels
                 if (CurrentPreferences.HasErrors)
                 {
                     AddError(currentProperty, "Invalid Preferences!");
+
+                    if (CurrentPreferences.GetErrors(nameof(CurrentPreferences.DownloadSplitTime)) is List<string> downloadSplitTimeErrors && downloadSplitTimeErrors.Count > 0)
+                    {
+                        string firstError = downloadSplitTimeErrors.First();
+                        AddError(nameof(DownloadSplitTimeHours), firstError);
+                        AddError(nameof(DownloadSplitTimeMinutes), firstError);
+                        AddError(nameof(DownloadSplitTimeSeconds), firstError);
+                    }
                 }
             }
         }

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
@@ -194,8 +194,9 @@ namespace TwitchLeecher.Gui.ViewModels
                                 ? Path.Combine(currentPrefs.DownloadFolder, video.Channel)
                                 : currentPrefs.DownloadFolder;
 
-                            string filename = _filenameService.SubstituteWildcards(currentPrefs.DownloadFileName, video);
+                            string filename = currentPrefs.DownloadFileName;
                             filename = _filenameService.EnsureExtension(filename, currentPrefs.DownloadDisableConversion);
+                            filename = _filenameService.SubstituteWildcards(filename, folder, _twitchService.IsFileNameUsed, video);
 
                             DownloadParameters downloadParams = new DownloadParameters(video, vodAuthInfo, video.Qualities.First(), folder, filename, currentPrefs.DownloadDisableConversion);
 

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
@@ -106,6 +106,9 @@
                         <RowDefinition SharedSizeGroup="g2" />
                         <RowDefinition Height="5" />
                         <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition Height="5" />
+                        <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition SharedSizeGroup="g2" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -116,6 +119,10 @@
                         <ColumnDefinition Width="3" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="12" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="3" />
                         <ColumnDefinition Width="Auto" />
@@ -134,6 +141,18 @@
                     <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
                     <TextBlock Grid.Row="2" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
                     <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+
+                    <CheckBox Grid.Row="4" Grid.Column="0" IsChecked="{Binding AutoSplitUseExtended}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Row="4" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+                    <TextBlock Grid.Row="4" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+                    <TextBlock Grid.Row="4" Grid.Column="12"  Text="Overlap" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="14" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadParams.AutoSplitOverlap, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99"/>
+                    
+                    <TextBlock Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="9" Text="{Binding AutoSplitPartCount, StringFormat='Video parts: {0}', FallbackValue='Video count: 1'}" VerticalAlignment="Center" HorizontalAlignment="Center" 
+                               Visibility="{Binding AutoSplitUseExtended, Converter={StaticResource ResourceKey='BVConverter'}}"/>
                 </Grid>
             </Grid>
         </Grid>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
@@ -1,9 +1,10 @@
 ﻿<UserControl x:Class="TwitchLeecher.Gui.Views.DownloadView"
-        x:Name="control"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
-        xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters">
+             x:Name="control"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
+             xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
+             xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -135,12 +136,25 @@
                     <TextBlock Grid.Row="0" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
                     <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" />
 
-                    <CheckBox Grid.Row="2" Grid.Column="0" IsChecked="{Binding  DownloadParams.CropEnd}" Content="End" VerticalAlignment="Center" />
+                    <CheckBox Grid.Row="2" Grid.Column="0" IsChecked="{Binding DownloadParams.CropEnd}" Content="End" VerticalAlignment="Center" IsEnabled="{Binding DownloadParams.StreamingNow, Converter={StaticResource InverseBoolConverter}}"/>
                     <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" Maximum="99" Loop="False" />
                     <TextBlock Grid.Row="2" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
                     <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
                     <TextBlock Grid.Row="2" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
                     <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+                    <CheckBox Grid.Row="2" Grid.Column="12" Grid.ColumnSpan="3" IsChecked="{Binding DownloadParams.StreamingNow}" Content="Online" VerticalAlignment="Center" />
+                    <fa:ImageAwesome Grid.Row="2" Grid.Column="14" Style="{StaticResource Img_Help}">
+                        <fa:ImageAwesome.ToolTip>
+                            <ToolTip Width="350">
+                                <StackPanel>
+                                    <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Download live stream" />
+                                    <TextBlock TextAlignment="Justify">
+                                        Download living stream until it end. Check new parts every 5 minutes, also able to auto split video. Incompatible with end crop
+                                    </TextBlock>
+                                </StackPanel>
+                            </ToolTip>
+                        </fa:ImageAwesome.ToolTip>
+                    </fa:ImageAwesome>
 
                     <CheckBox Grid.Row="4" Grid.Column="0" IsChecked="{Binding AutoSplitUseExtended}" Content="Auto" VerticalAlignment="Center" />
                     <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99" Loop="False" />

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
@@ -97,6 +97,18 @@
                                                             <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
                                                             <Setter Property="ToolTip" Value="Cancel" />
                                                         </DataTrigger>
+                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.WaitConcatenation}">
+                                                            <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
+                                                            <Setter Property="ToolTip" Value="Cancel" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Concatenation}">
+                                                            <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
+                                                            <Setter Property="ToolTip" Value="Cancel" />
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Converting}">
+                                                            <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
+                                                            <Setter Property="ToolTip" Value="Cancel" />
+                                                        </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>
                                             </Button.Style>
@@ -106,6 +118,15 @@
                                                         <Setter Property="Icon" Value="Times" />
                                                         <Style.Triggers>
                                                             <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Downloading}">
+                                                                <Setter Property="Icon" Value="Ban" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.WaitConcatenation}">
+                                                                <Setter Property="Icon" Value="Ban" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Concatenation}">
+                                                                <Setter Property="Icon" Value="Ban" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Converting}">
                                                                 <Setter Property="Icon" Value="Ban" />
                                                             </DataTrigger>
                                                         </Style.Triggers>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
@@ -27,7 +27,7 @@
                                 </fa:ImageAwesome.Foreground>
                             </fa:ImageAwesome>
                         </StackPanel>
-                    </DataTemplate>
+                    </DataTemplate> 
 
                     <Style x:Key="thisStyle" TargetType="{x:Type UserControl}">
                         <Style.Triggers>
@@ -156,6 +156,8 @@
                                         <RowDefinition SharedSizeGroup="g1" />
                                         <RowDefinition Height="10" />
                                         <RowDefinition SharedSizeGroup="g1" />
+                                        <RowDefinition Height="10" />
+                                        <RowDefinition SharedSizeGroup="g1" />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Column="0" Grid.Row="0" Text="Status:" FontWeight="Bold" />
@@ -169,13 +171,16 @@
                                     <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding DownloadParams.Video.Game}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="4" Text="Length:" FontWeight="Bold" />
-                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.CroppedLengthStr}" />
+                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.VideoLengthStr}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="6" Text="Recorded:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="6" Text="{Binding DownloadParams.Video.RecordedDate, StringFormat=G}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="8" Text="Quality:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="8" Text="{Binding DownloadParams.Quality.DisplayString}" />
+
+                                    <TextBlock Grid.Column="0" Grid.Row="10" Text="File name:" FontWeight="Bold" />
+                                    <TextBlock Grid.Column="2" Grid.Row="10" Text="{Binding DownloadParams.FullPath}" />
                                 </Grid>
                             </Grid>
                             <Border Grid.Row="2" BorderThickness="0,1,0,0" Padding="0,10,0,0" Margin="0,10,0,0">

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
@@ -97,15 +97,11 @@
                                                             <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
                                                             <Setter Property="ToolTip" Value="Cancel" />
                                                         </DataTrigger>
-                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.WaitConcatenation}">
+                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Waiting}">
                                                             <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
                                                             <Setter Property="ToolTip" Value="Cancel" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Concatenation}">
-                                                            <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
-                                                            <Setter Property="ToolTip" Value="Cancel" />
-                                                        </DataTrigger>
-                                                        <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Converting}">
                                                             <Setter Property="Command" Value="{Binding Path=DataContext.CancelDownloadCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}}" />
                                                             <Setter Property="ToolTip" Value="Cancel" />
                                                         </DataTrigger>
@@ -120,13 +116,10 @@
                                                             <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Downloading}">
                                                                 <Setter Property="Icon" Value="Ban" />
                                                             </DataTrigger>
-                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.WaitConcatenation}">
+                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Waiting}">
                                                                 <Setter Property="Icon" Value="Ban" />
                                                             </DataTrigger>
                                                             <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Concatenation}">
-                                                                <Setter Property="Icon" Value="Ban" />
-                                                            </DataTrigger>
-                                                            <DataTrigger Binding="{Binding DownloadState}" Value="{x:Static enums:DownloadState.Converting}">
                                                                 <Setter Property="Icon" Value="Ban" />
                                                             </DataTrigger>
                                                         </Style.Triggers>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/InfoView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/InfoView.xaml
@@ -32,6 +32,7 @@
                 <RowDefinition />
                 <RowDefinition />
                 <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
 
             <StackPanel Grid.Row="0" Orientation="Horizontal">
@@ -40,17 +41,17 @@
             </StackPanel>
 
             <TextBlock Grid.Row="1" Text="Developer" FontWeight="Bold"  Margin="0,15,0,0" />
-            <TextBlock Grid.Row="2" Text="Dominik &quot;Franiac&quot; Rebitzer" Margin="15,5,0,0" />
+            <TextBlock Grid.Row="2" Text="Dominik &quot;Franiac&quot; Rebitzer (and Targen (me))" Margin="15,5,0,0" />
 
             <TextBlock Grid.Row="3" Text="Contact" FontWeight="Bold"  Margin="0,15,0,0" />
             <TextBlock Grid.Row="4" Margin="15,5,0,0">
-            <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="mailto:contact@franiac.com">
-                contact@franiac.com
+            <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="mailto:targen005@gmail.com">
+                targen005@gmail.com
             </Hyperlink>
             </TextBlock>
 
             <TextBlock Grid.Row="5" Text="Donate" FontWeight="Bold"  Margin="0,15,0,0" />
-            <TextBlock Grid.Row="6" Text="Help me out with a bottle of beer if you like the program :)" Margin="15,5,0,0" />
+            <TextBlock Grid.Row="6" Text="Help creator out with a bottle of beer if you like the program :)" Margin="15,5,0,0" />
             <Button Grid.Row="7" Command="{Binding DonateCommand}" HorizontalAlignment="Left" Height="Auto" Margin="15,5,0,0" Cursor="Hand">
                 <Button.Style>
                     <Style TargetType="{x:Type Button}">
@@ -79,38 +80,43 @@
 
             <TextBlock Grid.Row="8" Text="Source Code &amp; Documentation" FontWeight="Bold"  Margin="0,15,0,0" />
             <TextBlock Grid.Row="9" Margin="15,5,0,0">
+            <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://github.com/Targen92/TwitchLeecher">
+                http://github.com/Targen92/TwitchLeecher
+            </Hyperlink>
+            </TextBlock>
+            <TextBlock Grid.Row="10" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://github.com/Franiac/TwitchLeecher">
                 http://github.com/Franiac/TwitchLeecher
             </Hyperlink>
             </TextBlock>
 
-            <TextBlock Grid.Row="10" Text="Links" FontWeight="Bold"  Margin="0,15,0,0" />
-            <TextBlock Grid.Row="11" Margin="15,5,0,0">
+            <TextBlock Grid.Row="11" Text="Links" FontWeight="Bold"  Margin="0,15,0,0" />
+            <TextBlock Grid.Row="12" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://www.fakesmilerevolution.com">
                 http://www.fakesmilerevolution.com
             </Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Row="12" Margin="15,5,0,0">
+            <TextBlock Grid.Row="13" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://www.twitch.tv/fakesmilerevolution">
                 http://www.twitch.tv/fakesmilerevolution
             </Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Row="13" Margin="15,5,0,0">
+            <TextBlock Grid.Row="14" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://plus.google.com/+fakesmilerevolution">
                 http://plus.google.com/+fakesmilerevolution
             </Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Row="14" Margin="15,5,0,0">
+            <TextBlock Grid.Row="15" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://www.youtube.com/fakesmilerevolution">
                 http://www.youtube.com/fakesmilerevolution
             </Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Row="15" Margin="15,5,0,0">
+            <TextBlock Grid.Row="16" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://www.facebook.com/fakesmilerevolution">
                 http://www.facebook.com/fakesmilerevolution
             </Hyperlink>
             </TextBlock>
-            <TextBlock Grid.Row="16" Margin="15,5,0,0">
+            <TextBlock Grid.Row="17" Margin="15,5,0,0">
             <Hyperlink Command="{Binding OpenLinkCommand}" CommandParameter="http://www.soundcloud.com/fakesmilerevolution">
                 http://www.soundcloud.com/fakesmilerevolution
             </Hyperlink>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -313,6 +313,12 @@
                                         <RowDefinition SharedSizeGroup="r2" />
                                         <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -338,37 +344,49 @@
                                     <TextBlock Grid.Row="6" Grid.Column="2" Text="Recording date (yyyyMMdd)" />
                                     <TextBlock Grid.Row="6" Grid.Column="4" Text="20160418" />
 
-                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{time}" />
-                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording time" />
-                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="034622PM" />
+                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{date-}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording date (yyyy-MM-dd)" />
+                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="2016-04-18" />
 
-                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time24}" />
-                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time (24 hours)" />
-                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="174622" />
+                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time}" />
+                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="034622PM" />
 
-                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{id}" />
-                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Twitch video ID" />
-                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="54869708" />
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{time-}" />
+                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="03-46-22_PM" />
 
-                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{title}" />
-                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Video Title" />
-                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="Best Strim Evr!!!" />
+                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{time24}" />
+                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="174622" />
 
-                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{res}" />
-                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Video Resolution" />
-                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="1280x720" />
+                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{time24-}" />
+                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="17-46-22" />
 
-                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{fps}" />
-                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Video Framerate" />
-                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="60" />
+                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{id}" />
+                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Twitch video ID" />
+                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="54869708" />
 
-                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{start}" />
-                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Crop start time (HHmmss)" />
-                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="012744" />
+                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{title}" />
+                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Video Title" />
+                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="Best Strim Evr!!!" />
 
-                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{end}" />
-                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Crop end time (HHmmss)" />
-                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="025317" />
+                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{res}" />
+                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Video Resolution" />
+                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="1280x720" />
+
+                                    <TextBlock Grid.Row="24" Grid.Column="0" Text="{}{fps}" />
+                                    <TextBlock Grid.Row="24" Grid.Column="2" Text="Video Framerate" />
+                                    <TextBlock Grid.Row="24" Grid.Column="4" Text="60" />
+
+                                    <TextBlock Grid.Row="26" Grid.Column="0" Text="{}{start}" />
+                                    <TextBlock Grid.Row="26" Grid.Column="2" Text="Crop start time (HHmmss)" />
+                                    <TextBlock Grid.Row="26" Grid.Column="4" Text="012744" />
+
+                                    <TextBlock Grid.Row="28" Grid.Column="0" Text="{}{end}" />
+                                    <TextBlock Grid.Row="28" Grid.Column="2" Text="Crop end time (HHmmss)" />
+                                    <TextBlock Grid.Row="28" Grid.Column="4" Text="025317" />
                                 </Grid>
                             </StackPanel>
                         </ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -319,6 +319,8 @@
                                         <RowDefinition SharedSizeGroup="r2" />
                                         <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -387,6 +389,10 @@
                                     <TextBlock Grid.Row="28" Grid.Column="0" Text="{}{end}" />
                                     <TextBlock Grid.Row="28" Grid.Column="2" Text="Crop end time (HHmmss)" />
                                     <TextBlock Grid.Row="28" Grid.Column="4" Text="025317" />
+                                    
+                                    <TextBlock Grid.Row="30" Grid.Column="0" Text="{}{unumber}" />
+                                    <TextBlock Grid.Row="30" Grid.Column="2" Text="Number to avoid overwrite" />
+                                    <TextBlock Grid.Row="30" Grid.Column="4" Text="1" />
                                 </Grid>
                             </StackPanel>
                         </ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
              xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
              xmlns:enums="clr-namespace:TwitchLeecher.Core.Enums;assembly=TwitchLeecher.Core"
+             xmlns:prefs="clr-namespace:TwitchLeecher.Core.Models;assembly=TwitchLeecher.Core"
              xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
@@ -18,6 +19,7 @@
                     <converters:VideoQualityToTextConverter x:Key="videoQualityToTextConverter" />
                     <converters:LoadLimitToBooleanConverter x:Key="loadLimitToBooleanConverter" />
                     <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
+                    <converters:InverseBooleanConverter x:Key="InverseBoolConverter"/>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -419,7 +421,7 @@
                             <StackPanel>
                                 <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Quality by default" />
                                 <TextBlock TextAlignment="Justify">
-                                    Specify quality that will be select for download by default. If there are no selected quality, it will be empty and you will have to select it manually.
+                                    Specify quality that will be select for download by default. If video hasn't selected quality, you will have to select it manually.
                                 </TextBlock>
                             </StackPanel>
                         </ToolTip>
@@ -481,6 +483,8 @@
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
+                    <RowDefinition SharedSizeGroup="r1" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="g2" />
@@ -528,6 +532,47 @@
                                 <TextBlock TextAlignment="Justify">
                                         The external video player to use (preferably VLC because it works great with Twitch streams)
                                 </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+                
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Auto Split" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <Grid Grid.Row="4" Grid.Column="2" Grid.IsSharedSizeScope="True" IsEnabled="{Binding CurrentPreferences.DownloadDisableConversion, Converter={StaticResource InverseBoolConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" IsChecked="{Binding CurrentPreferences.DownloadSplitUse}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                    <TextBlock Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                    <TextBlock Grid.Column="12"  Text="Overlap" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="14" Style="{StaticResource TlTimeUpDown}" Value="{Binding CurrentPreferences.SplitOverlapSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" Maximum="99"/>
+                </Grid>
+                <fa:ImageAwesome Grid.Row="4" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Auto Split" />
+                                <TextBlock TextAlignment="Justify" Text="{Binding Path=(prefs:Preferences.MinSplitLength), 
+                                    StringFormat='Auto split stream in part with this length. Also add extra seconds to overlap between video parts. Split time has to be at least {0} seconds, parts smaller will be attached to previous part.'}"/>
                             </StackPanel>
                         </ToolTip>
                     </fa:ImageAwesome.ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -237,6 +237,8 @@
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
+                    <RowDefinition SharedSizeGroup="r1" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="g2" />
@@ -442,8 +444,22 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadAndConcatSimultaneously}" Content="Download and concatenating videos simultaneously" VerticalAlignment="Center" HorizontalAlignment="Left" />
                 <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip  Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Download and concatenate simultaneously" />
+                                <TextBlock TextAlignment="Justify">
+                                    Start downloading next video in the moment when previous video has downloaded and start concatination. It download all videos faster, but load drive more.
+                                </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+                
+                <CheckBox Grid.Row="12" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="12" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -456,14 +472,14 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="12" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="12" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="14" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="14" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
                                 <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Disable conversion to mp4" />
                                 <TextBlock TextAlignment="Justify">
-                                    Depending on the video containing muted parts, frame drops or the encoding settings of the streamer, the conversion to mp4 can introduce A/V desync in rare cases. If you want to download the raw .ts video file from Twitch, enable this option. Cropping is not available in this mode.
+                                    Depending on the video containing muted parts, frame drops or the encoding settings of the streamer, the conversion to mp4 can introduce A/V desync in rare cases. If you want to download the raw .ts video file from Twitch, enable this option. Cropping (and autosplit) is not available in this mode.
                                 </TextBlock>
                             </StackPanel>
                         </ToolTip>
@@ -495,7 +511,7 @@
                 </Grid.ColumnDefinitions>
 
                 <CheckBox Grid.Row="0" Grid.Column="2" Content="Use external video player" IsChecked="{Binding CurrentPreferences.MiscUseExternalPlayer}" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="0" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <fa:ImageAwesome Grid.Row="0" Grid.Column="4" Style="{StaticResource Img_Help}"><!--TODO-->
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip Width="350">
                             <StackPanel>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
              xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
              xmlns:enums="clr-namespace:TwitchLeecher.Core.Enums;assembly=TwitchLeecher.Core"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -14,6 +15,7 @@
                 <ResourceDictionary Source="../Theme/Images.xaml" />
                 <ResourceDictionary>
                     <converters:VideoTypeToBooleanConverter x:Key="videoTypeToBooleanConverter" />
+                    <converters:VideoQualityToTextConverter x:Key="videoQualityToTextConverter" />
                     <converters:LoadLimitToBooleanConverter x:Key="loadLimitToBooleanConverter" />
                     <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
                 </ResourceDictionary>
@@ -211,7 +213,17 @@
             </Border>
 
             <Grid Grid.Row="5" Margin="15,0,0,0">
+                <Grid.Resources>
+                    <ObjectDataProvider x:Key="dataFromEnum" MethodName="GetValues"
+                        ObjectType="{x:Type System:Enum}">
+                        <ObjectDataProvider.MethodParameters>
+                            <x:Type TypeName="enums:VideoQuality"/>
+                        </ObjectDataProvider.MethodParameters>
+                    </ObjectDataProvider>
+                </Grid.Resources>
                 <Grid.RowDefinitions>
+                    <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
@@ -398,9 +410,24 @@
                         </ToolTip>
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
-
-                <CheckBox Grid.Row="6" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="Quality by default" VerticalAlignment="Center" />
+                <ComboBox Grid.Row="6" Grid.Column="2" VerticalAlignment="Center" ItemsSource="{Binding Source={StaticResource dataFromEnum}, Converter={StaticResource videoQualityToTextConverter}}" SelectedItem="{Binding CurrentPreferences.DownloadQuality, Converter={StaticResource videoQualityToTextConverter}}"/>
                 <fa:ImageAwesome Grid.Row="6" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip  Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Quality by default" />
+                                <TextBlock TextAlignment="Justify">
+                                    Specify quality that will be select for download by default. If there are no selected quality, it will be empty and you will have to select it manually.
+                                </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+
+                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -413,8 +440,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -427,8 +454,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="12" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="12" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/UpdateInfoView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/UpdateInfoView.xaml
@@ -41,7 +41,7 @@
 
             <TextBlock Grid.Row="4">
                 <Hyperlink Command="{Binding DownloadCommand}" NavigateUri="{Binding UpdateInfo.DownloadUrl, Mode=OneWay}">
-                    <TextBlock Text="{Binding UpdateInfo.DownloadUrl, Mode=OneWay, FallbackValue='https://github.com/Franiac/TwitchLeecher/releases/tag/vX.Y.Z'}" />
+                    <TextBlock Text="{Binding UpdateInfo.DownloadUrl, Mode=OneWay, FallbackValue='https://github.com/Targen92/TwitchLeecher/releases/tag/vX.Y.Z'}" />
                 </Hyperlink>
             </TextBlock>
 

--- a/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
@@ -5,7 +5,7 @@ namespace TwitchLeecher.Services.Interfaces
 {
     public interface IFilenameService
     {
-        string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
+        string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
 
         string SubstituteInvalidChars(string filename, string replaceStr);
 

--- a/TwitchLeecher/TwitchLeecher.Services/Interfaces/IProcessingService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Interfaces/IProcessingService.cs
@@ -7,7 +7,7 @@ namespace TwitchLeecher.Services.Interfaces
     {
         string FFMPEGExe { get; }
 
-        void ConcatParts(Action<string> log, Action<string> setStatus, Action<double> setProgress, VodPlaylist vodPlaylist, string concatFile);
+        void ConcatParts(Action<string> log, Action<string> setStatus, Action<double> setProgress, VodPlaylist vodPlaylist, string concatFile, bool removeFiles = true);
 
         void ConvertVideo(Action<string> log, Action<string> setStatus, Action<double> setProgress, Action<bool> setIsIndeterminate, string sourceFile, string outputFile, CropInfo cropInfo);
     }

--- a/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
@@ -12,7 +12,7 @@ namespace TwitchLeecher.Services.Services
     {
         #region Methods
 
-        public string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
+        public string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
         {
             if (video == null)
             {
@@ -48,6 +48,14 @@ namespace TwitchLeecher.Services.Services
             result = result.Replace(FilenameWildcards.END, selectedCropEnd.ToShortDaylessString());
 
             result = SubstituteInvalidChars(result, "_");
+
+            if (result.Contains(FilenameWildcards.UNIQNUMBER))
+            {
+                int index = 1;
+                while (File.Exists(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))) || IsFileNameUsed(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))))
+                    index++;
+                result = result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString());
+            }
 
             return result;
         }

--- a/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
@@ -37,6 +37,9 @@ namespace TwitchLeecher.Services.Services
             result = result.Replace(FilenameWildcards.DATE, recorded.ToString("yyyyMMdd"));
             result = result.Replace(FilenameWildcards.TIME, recorded.ToString("hhmmsstt", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.TIME24, recorded.ToString("HHmmss", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.DATE_, recorded.ToString("yyyy-MM-dd"));
+            result = result.Replace(FilenameWildcards.TIME_, recorded.ToString("hh-mm-ss_tt", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.TIME24_, recorded.ToString("HH-mm-ss", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.ID, video.Id);
             result = result.Replace(FilenameWildcards.TITLE, video.Title);
             result = result.Replace(FilenameWildcards.RES, !string.IsNullOrWhiteSpace(selectedQuality.Resolution) ? selectedQuality.Resolution : TwitchVideoQuality.UNKNOWN);

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -48,6 +48,8 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_SPLITTIME_EL = "SplitTime";
         private const string DOWNLOAD_SPLITOVERLAP_EL = "SplitOverlapSeconds";
 
+        private const string DOWNLOAD_CONCAT_SIMULTANEOUSLY_EL = "DownloadAndConcatSimultaneously";
+        
         private const string MISC_EL = "Misc";
         private const string MISC_USEEXTERNALPLAYER_EL = "UseExternalPlayer";
         private const string MISC_EXTERNALPLAYER_EL = "ExternalPlayer";
@@ -227,6 +229,10 @@ namespace TwitchLeecher.Services.Services
                 XElement downloadDisableConversionEl = new XElement(DOWNLOAD_DISABLECONVERSION_EL);
                 downloadDisableConversionEl.SetValue(preferences.DownloadDisableConversion);
                 downloadEl.Add(downloadDisableConversionEl);
+
+                XElement downloadAndConcatSimultaneouslyEl = new XElement(DOWNLOAD_CONCAT_SIMULTANEOUSLY_EL);
+                downloadAndConcatSimultaneouslyEl.SetValue(preferences.DownloadAndConcatSimultaneously);
+                downloadEl.Add(downloadAndConcatSimultaneouslyEl);
 
                 XElement downloadSplitUseEl = new XElement(DOWNLOAD_SPLITUSE_EL);
                 downloadSplitUseEl.SetValue(preferences.DownloadSplitUse);
@@ -549,6 +555,20 @@ namespace TwitchLeecher.Services.Services
                             }
                         }
 
+                        XElement downloadAndConcatSimultaneouslyEl = downloadEl.Element(DOWNLOAD_CONCAT_SIMULTANEOUSLY_EL);
+
+                        if (downloadAndConcatSimultaneouslyEl != null)
+                        {
+                            try
+                            {
+                                preferences.DownloadAndConcatSimultaneously = downloadAndConcatSimultaneouslyEl.GetValueAsBool();
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
                         XElement downloadSplitUseEl = downloadEl.Element(DOWNLOAD_SPLITUSE_EL);
 
                         if (downloadSplitUseEl != null)
@@ -649,6 +669,7 @@ namespace TwitchLeecher.Services.Services
                 DownloadQuality = VideoQuality.Source,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,
+                DownloadAndConcatSimultaneously = false,
                 DownloadSplitTime = new TimeSpan(),
                 DownloadSplitUse = false,
                 MiscUseExternalPlayer = false,

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -44,6 +44,9 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_SUBFOLDERSFORFAV_EL = "SubfoldersForFav";
         private const string DOWNLOAD_REMOVECOMPLETED_EL = "RemoveCompleted";
         private const string DOWNLOAD_DISABLECONVERSION_EL = "DisableConversion";
+        private const string DOWNLOAD_SPLITUSE_EL = "SplitUse";
+        private const string DOWNLOAD_SPLITTIME_EL = "SplitTime";
+        private const string DOWNLOAD_SPLITOVERLAP_EL = "SplitOverlapSeconds";
 
         private const string MISC_EL = "Misc";
         private const string MISC_USEEXTERNALPLAYER_EL = "UseExternalPlayer";
@@ -224,6 +227,18 @@ namespace TwitchLeecher.Services.Services
                 XElement downloadDisableConversionEl = new XElement(DOWNLOAD_DISABLECONVERSION_EL);
                 downloadDisableConversionEl.SetValue(preferences.DownloadDisableConversion);
                 downloadEl.Add(downloadDisableConversionEl);
+
+                XElement downloadSplitUseEl = new XElement(DOWNLOAD_SPLITUSE_EL);
+                downloadSplitUseEl.SetValue(preferences.DownloadSplitUse);
+                downloadEl.Add(downloadSplitUseEl);
+                
+                XElement downloadSplitTimeEl = new XElement(DOWNLOAD_SPLITTIME_EL);
+                downloadSplitTimeEl.SetValue(DateTime.MinValue + preferences.DownloadSplitTime);
+                downloadEl.Add(downloadSplitTimeEl);
+
+                XElement splitOverlapSecondsEl = new XElement(DOWNLOAD_SPLITOVERLAP_EL);
+                splitOverlapSecondsEl.SetValue(preferences.SplitOverlapSeconds);
+                downloadEl.Add(splitOverlapSecondsEl);
 
                 // Miscellanious
                 XElement miscUseExternalPlayerEl = new XElement(MISC_USEEXTERNALPLAYER_EL);
@@ -534,6 +549,48 @@ namespace TwitchLeecher.Services.Services
                             }
                         }
 
+                        XElement downloadSplitUseEl = downloadEl.Element(DOWNLOAD_SPLITUSE_EL);
+
+                        if (downloadSplitUseEl != null)
+                        {
+                            try
+                            {
+                                preferences.DownloadSplitUse = downloadSplitUseEl.GetValueAsBool();
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
+                        XElement downloadSplitTimeEl = downloadEl.Element(DOWNLOAD_SPLITTIME_EL);
+
+                        if (downloadSplitTimeEl != null)
+                        {
+                            try
+                            {
+                                preferences.DownloadSplitTime = downloadSplitTimeEl.GetValueAsDateTime() - DateTime.MinValue;
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
+                        XElement splitOverlapSecondsEl = downloadEl.Element(DOWNLOAD_SPLITOVERLAP_EL);
+
+                        if (splitOverlapSecondsEl != null)
+                        {
+                            try
+                            {
+                                preferences.SplitOverlapSeconds = splitOverlapSecondsEl.GetValueAsInt();
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
                         XElement miscEl = preferencesEl.Element(MISC_EL);
 
                         if (miscEl != null)
@@ -592,8 +649,11 @@ namespace TwitchLeecher.Services.Services
                 DownloadQuality = VideoQuality.Source,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,
+                DownloadSplitTime = new TimeSpan(),
+                DownloadSplitUse = false,
                 MiscUseExternalPlayer = false,
-                MiscExternalPlayer = null
+                MiscExternalPlayer = null,
+                SplitOverlapSeconds = 10,
             };
 
             return preferences;

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -40,6 +40,7 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_TEMPFOLDER_EL = "TempFolder";
         private const string DOWNLOAD_FOLDER_EL = "Folder";
         private const string DOWNLOAD_FILENAME_EL = "FileName";
+        private const string DOWNLOAD_QUALITY_EL = "Quality";
         private const string DOWNLOAD_SUBFOLDERSFORFAV_EL = "SubfoldersForFav";
         private const string DOWNLOAD_REMOVECOMPLETED_EL = "RemoveCompleted";
         private const string DOWNLOAD_DISABLECONVERSION_EL = "DisableConversion";
@@ -207,6 +208,10 @@ namespace TwitchLeecher.Services.Services
                     downloadFileNameEl.SetValue(preferences.DownloadFileName);
                     downloadEl.Add(downloadFileNameEl);
                 }
+
+                XElement downloadQualityEl = new XElement(DOWNLOAD_QUALITY_EL);
+                downloadQualityEl.SetValue(preferences.DownloadQuality);
+                downloadEl.Add(downloadQualityEl);
 
                 XElement downloadSubfoldersForFavEl = new XElement(DOWNLOAD_SUBFOLDERSFORFAV_EL);
                 downloadSubfoldersForFavEl.SetValue(preferences.DownloadSubfoldersForFav);
@@ -472,6 +477,20 @@ namespace TwitchLeecher.Services.Services
                                 }
                             }
 
+                            XElement downloadQualityEl = downloadEl.Element(DOWNLOAD_QUALITY_EL);
+
+                            if (downloadQualityEl != null)
+                            {
+                                try
+                                {
+                                    preferences.DownloadQuality = downloadQualityEl.GetValueAsEnum<VideoQuality>();
+                                }
+                                catch
+                                {
+                                    // Value from config file could not be loaded, use default value
+                                }
+                            }
+
                             XElement donwloadSubfolderForFavEl = downloadEl.Element(DOWNLOAD_SUBFOLDERSFORFAV_EL);
 
                             if (donwloadSubfolderForFavEl != null)
@@ -570,6 +589,7 @@ namespace TwitchLeecher.Services.Services
                 DownloadTempFolder = _folderService.GetTempFolder(),
                 DownloadFolder = _folderService.GetDownloadFolder(),
                 DownloadFileName = FilenameWildcards.DATE + "_" + FilenameWildcards.ID + "_" + FilenameWildcards.GAME,
+                DownloadQuality = VideoQuality.Source,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,
                 MiscUseExternalPlayer = false,

--- a/TwitchLeecher/TwitchLeecher.Services/Services/ProcessingService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/ProcessingService.cs
@@ -37,7 +37,7 @@ namespace TwitchLeecher.Services.Services
 
         #region Methods
 
-        public void ConcatParts(Action<string> log, Action<string> setStatus, Action<double> setProgress, VodPlaylist vodPlaylist, string concatFile)
+        public void ConcatParts(Action<string> log, Action<string> setStatus, Action<double> setProgress, VodPlaylist vodPlaylist, string concatFile, bool removeFiles = true)
         {
             setStatus("Merging files");
             setProgress(0);
@@ -63,7 +63,8 @@ namespace TwitchLeecher.Services.Services
                         }
                     }
 
-                    FileSystem.DeleteFile(part.LocalFile);
+                    if (removeFiles)
+                        FileSystem.DeleteFile(part.LocalFile);
 
                     setProgress(i * 100 / partsCount);
                 }

--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -733,6 +733,7 @@ namespace TwitchLeecher.Services.Services
 
                         TimeSpan cropStartTime = downloadParams.CropStartTime;
                         TimeSpan cropEndTime = downloadParams.CropEndTime;
+                        TimeSpan totalTime = downloadParams.CropEndTime;
 
                         TwitchVideoQuality quality = downloadParams.Quality;
 
@@ -757,6 +758,10 @@ namespace TwitchLeecher.Services.Services
                             cancellationToken.ThrowIfCancellationRequested();
 
                             string playlistUrl = RetrievePlaylistUrlForQuality(log, quality, vodId, vodAuthInfo);
+                            totalTime = CalcTotalTime(curVodPlaylist);
+                            if (!cropEnd)//Update total video time of downloads tab
+                                downloadParams.CropEndTime = totalTime;
+                            downloadParams.Video.Length = totalTime;
 
                             cancellationToken.ThrowIfCancellationRequested();
 
@@ -942,6 +947,16 @@ namespace TwitchLeecher.Services.Services
 
                 return vodPlaylist;
             }
+        }
+        private TimeSpan CalcTotalTime(VodPlaylist vodPlaylist)
+        {
+            double lengthSum = 0;
+            foreach (VodPlaylistPart part in vodPlaylist)
+            {
+                double partLength = part.Length;
+                lengthSum += partLength;
+            }
+            return new TimeSpan(0, 0, (int)lengthSum);
         }
 
         private CropInfo CropVodPlaylist(VodPlaylist vodPlaylist, bool cropStart, bool cropEnd, TimeSpan cropStartTime, TimeSpan cropEndTime)

--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -43,7 +43,7 @@ namespace TwitchLeecher.Services.Services
 
         private const int TIMER_INTERVALL = 2;
         private const int DOWNLOAD_RETRIES = 3;
-        private const int TIMER_STREAMINGNOW_INTERVALL = 500;
+        private const int TIMER_STREAMINGNOW_INTERVALL = 300;
         private const int DOWNLOAD_RETRY_TIME = 20;
 
         private const int TWITCH_MAX_LOAD_LIMIT = 100;
@@ -832,7 +832,7 @@ namespace TwitchLeecher.Services.Services
                                     alreadyDownloadedVodPlaylist.AddRange(curVodPlaylist);
                                     allVodPlaylist.AddRange(curVodPlaylist);
 
-                                    log($"{curVodPlaylist.Count} new parts, total video time {totalTime.ToString("HH:mm:ss")}");
+                                    log($"{curVodPlaylist.Count} new parts, total video time {totalTime.ToString()}");
 
                                     DownloadParts(log, setStatus, setProgress, curVodPlaylist, cancellationToken);
 

--- a/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/TwitchService.cs
@@ -43,6 +43,7 @@ namespace TwitchLeecher.Services.Services
 
         private const int TIMER_INTERVALL = 2;
         private const int DOWNLOAD_RETRIES = 3;
+        private const int TIMER_STREAMINGNOW_INTERVALL = 500;
         private const int DOWNLOAD_RETRY_TIME = 20;
 
         private const int TWITCH_MAX_LOAD_LIMIT = 100;
@@ -59,6 +60,7 @@ namespace TwitchLeecher.Services.Services
 
         private bool disposedValue = false;
 
+        private readonly IFilenameService _filenameService;
         private IPreferencesService _preferencesService;
         private IProcessingService _processingService;
         private IRuntimeDataService _runtimeDataService;
@@ -68,6 +70,7 @@ namespace TwitchLeecher.Services.Services
 
         private ObservableCollection<TwitchVideo> _videos;
         private ObservableCollection<TwitchVideoDownload> _downloads;
+        private ObservableCollection<TwitchVideoDownload> _streamingNowDownloads;
 
         private ConcurrentDictionary<string, DownloadTask> _downloadTasks;
         private Dictionary<string, Uri> _gameThumbnails;
@@ -86,11 +89,13 @@ namespace TwitchLeecher.Services.Services
         #region Constructors
 
         public TwitchService(
+            IFilenameService filenameService,
             IPreferencesService preferencesService,
             IProcessingService processingService,
             IRuntimeDataService runtimeDataService,
             IEventAggregator eventAggregator)
         {
+            _filenameService = filenameService;
             _preferencesService = preferencesService;
             _processingService = processingService;
             _runtimeDataService = runtimeDataService;
@@ -101,6 +106,8 @@ namespace TwitchLeecher.Services.Services
 
             _downloads = new ObservableCollection<TwitchVideoDownload>();
             _downloads.CollectionChanged += Downloads_CollectionChanged;
+
+            _streamingNowDownloads = new ObservableCollection<TwitchVideoDownload>();
 
             _downloadTasks = new ConcurrentDictionary<string, DownloadTask>();
 
@@ -724,20 +731,21 @@ namespace TwitchLeecher.Services.Services
                         string vodId = downloadParams.Video.Id;
                         string tempDir = Path.Combine(_preferencesService.CurrentPreferences.DownloadTempFolder, TEMP_PREFIX + downloadId);
                         string ffmpegFile = _processingService.FFMPEGExe;
-                        string concatFile = Path.Combine(tempDir, Path.GetFileNameWithoutExtension(downloadParams.FullPath) + ".ts");
-                        string outputFile = downloadParams.FullPath;
 
                         bool disableConversion = downloadParams.DisableConversion;
                         bool cropStart = downloadParams.CropStart;
                         bool cropEnd = downloadParams.CropEnd;
 
-                        TimeSpan cropStartTime = downloadParams.CropStartTime;
+                        TimeSpan cropStartTime = cropStart ? downloadParams.CropStartTime : new TimeSpan(0, 0, 0);
                         TimeSpan cropEndTime = downloadParams.CropEndTime;
                         TimeSpan totalTime = downloadParams.CropEndTime;
 
                         TwitchVideoQuality quality = downloadParams.Quality;
 
                         VodAuthInfo vodAuthInfo = downloadParams.VodAuthInfo;
+
+                        string prepareFileName = downloadParams.Filename;
+                        downloadParams.Filename = _filenameService.SubstituteWildcards(prepareFileName, downloadParams.Folder, IsFileNameUsed, downloadParams.Video, downloadParams.Quality, cropStartTime, totalTime);
 
                         Action<DownloadState> setDownloadState = download.SetDownloadState;
                         Action<string> log = download.AppendLog;
@@ -757,23 +765,155 @@ namespace TwitchLeecher.Services.Services
 
                             cancellationToken.ThrowIfCancellationRequested();
 
-                            string playlistUrl = RetrievePlaylistUrlForQuality(log, quality, vodId, vodAuthInfo);
+                            DateTime lastUpdateTime = DateTime.Now;
+                            string curPlaylistUrl = RetrievePlaylistUrlForQuality(log, quality, vodId, vodAuthInfo);
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            VodPlaylist curVodPlaylist = RetrieveVodPlaylist(log, tempDir, curPlaylistUrl);
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
                             totalTime = CalcTotalTime(curVodPlaylist);
                             if (!cropEnd)//Update total video time of downloads tab
                                 downloadParams.CropEndTime = totalTime;
                             downloadParams.Video.Length = totalTime;
 
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            VodPlaylist vodPlaylist = RetrieveVodPlaylist(log, tempDir, playlistUrl);
-
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            CropInfo cropInfo = CropVodPlaylist(vodPlaylist, cropStart, cropEnd, cropStartTime, cropEndTime);
+                            VodPlaylist allVodPlaylist = new VodPlaylist();
+                            allVodPlaylist.AddRange(curVodPlaylist);
 
                             cancellationToken.ThrowIfCancellationRequested();
 
-                            DownloadParts(log, setStatus, setProgress, vodPlaylist, cancellationToken);
+                            CropInfo curCropInfo = CropVodPlaylist(curVodPlaylist, cropStart, cropEnd, cropStartTime, cropEndTime);
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            DownloadParts(log, setStatus, setProgress, curVodPlaylist, cancellationToken);
+
+                            VodPlaylist alreadyDownloadedVodPlaylist = new VodPlaylist();
+                            alreadyDownloadedVodPlaylist.AddRange(curVodPlaylist);
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            if (downloadParams.StreamingNow)
+                            {
+                                do
+                                {
+                                    setStatus("Wait streaming");
+
+                                    for (int index = TIMER_STREAMINGNOW_INTERVALL - (int)(DateTime.Now - lastUpdateTime).TotalSeconds; index >= 0; index--)
+                                    {
+                                        Thread.Sleep(1000);
+                                        cancellationToken.ThrowIfCancellationRequested();
+                                    }
+
+                                    setStatus("Update information");
+
+                                    lastUpdateTime = DateTime.Now;
+                                    curPlaylistUrl = RetrievePlaylistUrlForQuality(log, quality, vodId, vodAuthInfo);
+
+                                    cancellationToken.ThrowIfCancellationRequested();
+
+                                    curVodPlaylist = RetrieveVodPlaylist(log, tempDir, curPlaylistUrl);
+
+                                    cancellationToken.ThrowIfCancellationRequested();
+
+                                    totalTime = CalcTotalTime(curVodPlaylist);
+                                    if (!cropEnd) downloadParams.CropEndTime = totalTime;
+                                    downloadParams.Video.Length = totalTime;
+
+                                    cancellationToken.ThrowIfCancellationRequested();
+
+                                    CropVodPlaylist(curVodPlaylist, cropStart, false, cropStartTime, totalTime);
+
+                                    cancellationToken.ThrowIfCancellationRequested();
+
+                                    curVodPlaylist.RemoveAll(x => alreadyDownloadedVodPlaylist.Where(y => x.LocalFile == y.LocalFile).Any());
+                                    alreadyDownloadedVodPlaylist.AddRange(curVodPlaylist);
+                                    allVodPlaylist.AddRange(curVodPlaylist);
+
+                                    log($"{curVodPlaylist.Count} new parts, total video time {totalTime.ToString("HH:mm:ss")}");
+
+                                    DownloadParts(log, setStatus, setProgress, curVodPlaylist, cancellationToken);
+
+                                    cancellationToken.ThrowIfCancellationRequested();
+
+                                    if (downloadParams.AutoSplit && downloadParams.AutoSplitTime.TotalSeconds < (totalTime.TotalSeconds - cropStartTime.TotalSeconds) - Preferences.MinSplitLength)
+                                    {
+                                        var splitTimes = TwitchVideo.GetListOfSplitTimes(totalTime, cropStart ? (TimeSpan?)cropStartTime : null, null, downloadParams.AutoSplitTime, downloadParams.AutoSplitOverlap);
+
+                                        for (int index = 0; index < splitTimes.Count - 1; index++)
+                                        {
+                                            downloadParams.Filename = prepareFileName;
+                                            downloadParams.Filename = _filenameService.SubstituteWildcards(prepareFileName, downloadParams.Folder, IsFileNameUsed, downloadParams.Video, downloadParams.Quality, cropStartTime, totalTime);
+                                            string tempOutputFile = downloadParams.FullPath;
+                                            string tempConcatFile = Path.Combine(tempDir, Path.GetFileNameWithoutExtension(downloadParams.FullPath) + ".ts");
+
+                                            downloadParams.CropStart = splitTimes[index].Item1.HasValue;
+                                            downloadParams.CropStartTime = splitTimes[index].Item1 ?? new TimeSpan();
+                                            downloadParams.CropEnd = splitTimes[index].Item2.HasValue;
+                                            downloadParams.CropEndTime = splitTimes[index].Item2 ?? totalTime;
+
+                                            cropStart = splitTimes[index + 1].Item1.HasValue;
+                                            cropStartTime = splitTimes[index + 1].Item1.Value;
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+
+                                            VodPlaylist tempVodPlaylist = new VodPlaylist();
+                                            tempVodPlaylist.AddRange(allVodPlaylist);
+                                            var tempCropInfo = CropVodPlaylist(tempVodPlaylist, downloadParams.CropStart, downloadParams.CropEnd, downloadParams.CropStartTime, downloadParams.CropEndTime);
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+
+                                            curVodPlaylist.Clear();
+                                            curVodPlaylist.AddRange(allVodPlaylist);
+                                            CropVodPlaylist(curVodPlaylist, cropStart, cropEnd, cropStartTime, cropEndTime);
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+
+                                            //Not delete parts
+                                            _processingService.ConcatParts(log, setStatus, setProgress, tempVodPlaylist, disableConversion ? tempOutputFile : tempConcatFile, false);
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+
+                                            //Now delete parts that are outdated
+                                            tempVodPlaylist.RemoveAll(x => curVodPlaylist.Where(y => x.LocalFile == y.LocalFile).Any());
+                                            foreach (var part in tempVodPlaylist)
+                                                FileSystem.DeleteFile(part.LocalFile);
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+
+                                            if (!disableConversion)
+                                            {
+                                                cancellationToken.ThrowIfCancellationRequested();
+
+                                                setStatus("Converting part");
+
+                                                _processingService.ConvertVideo(log, setStatus, setProgress, setIsIndeterminate, tempConcatFile, tempOutputFile, tempCropInfo);
+                                            }
+
+                                            cancellationToken.ThrowIfCancellationRequested();
+                                        }
+
+                                        downloadParams.CropStart = splitTimes[splitTimes.Count - 1].Item1.HasValue;
+                                        downloadParams.CropStartTime = splitTimes[splitTimes.Count - 1].Item1 ?? new TimeSpan();
+                                        downloadParams.Filename = prepareFileName;
+                                        downloadParams.Filename = _filenameService.SubstituteWildcards(prepareFileName, downloadParams.Folder, IsFileNameUsed, downloadParams.Video, downloadParams.Quality, cropStartTime, totalTime);
+
+                                        cancellationToken.ThrowIfCancellationRequested();
+
+                                        continue;//because it is possible only if there was new 
+                                    }
+                                }
+                                while (curVodPlaylist.Count > 0);
+
+                            }
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            curVodPlaylist.Clear();
+                            curVodPlaylist.AddRange(allVodPlaylist);
+                            curCropInfo = CropVodPlaylist(curVodPlaylist, cropStart, cropEnd, cropStartTime, cropEndTime);
 
                             cancellationToken.ThrowIfCancellationRequested();
 
@@ -781,18 +921,33 @@ namespace TwitchLeecher.Services.Services
 
                             WaitUntilAnyConcatination(log, setStatus, setDownloadState, download, cancellationToken);
 
+                            cancellationToken.ThrowIfCancellationRequested();
+
                             setDownloadState(DownloadState.Concatenation);
+                            
+                            downloadParams.Filename = prepareFileName;
+                            downloadParams.Filename = _filenameService.SubstituteWildcards(prepareFileName, downloadParams.Folder, IsFileNameUsed, downloadParams.Video, downloadParams.Quality, cropStartTime, downloadParams.CropEndTime);
+                            string outputFile = downloadParams.FullPath;
+                            string concatFile = Path.Combine(tempDir, Path.GetFileNameWithoutExtension(downloadParams.FullPath) + ".ts");
 
                             cancellationToken.ThrowIfCancellationRequested();
 
-                            _processingService.ConcatParts(log, setStatus, setProgress, vodPlaylist, disableConversion ? outputFile : concatFile);
+                            _processingService.ConcatParts(log, setStatus, setProgress, curVodPlaylist, disableConversion ? outputFile : concatFile);
 
                             if (!disableConversion)
                             {
                                 cancellationToken.ThrowIfCancellationRequested();
 
-                                _processingService.ConvertVideo(log, setStatus, setProgress, setIsIndeterminate, concatFile, outputFile, cropInfo);
+                                _processingService.ConvertVideo(log, setStatus, setProgress, setIsIndeterminate, concatFile, outputFile, curCropInfo);
                             }
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            allVodPlaylist.RemoveAll(x => !File.Exists(x.LocalFile));
+                            allVodPlaylist.ForEach(x => File.Delete(x.LocalFile));
+
+                            cancellationToken.ThrowIfCancellationRequested();
+
                         }, cancellationToken);
 
                         Task continueTask = downloadVideoTask.ContinueWith(task =>

--- a/TwitchLeecher/TwitchLeecher.Services/Services/UpdateService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/UpdateService.cs
@@ -14,8 +14,8 @@ namespace TwitchLeecher.Services.Services
     {
         #region Constants
 
-        private const string latestReleaseUrl = "https://github.com/Franiac/TwitchLeecher/releases/tag/v{0}";
-        private const string releasesApiUrl = "https://api.github.com/repos/Franiac/TwitchLeecher/releases";
+        private const string latestReleaseUrl = "https://github.com/Targen92/TwitchLeecher/releases/tag/v{0}";
+        private const string releasesApiUrl = "https://api.github.com/repos/Targen92/TwitchLeecher/releases";
 
         #endregion Constants
 


### PR DESCRIPTION
There are 5 commits:
Show filename, crop time in downloads tab.
Add 3 new wildcards with hyphen.
Add special wildcard, that will be replaced by some number to avoid overwrite.
Add new settings option - quality by default. Will be selected ONLY if this quality exist, in other cases you has to select quality manually (as now).
Add autosplit option (with special setting in preferences). You can download video by part automatically, with extra overlap option. Work only with conversation.