### PR TITLE
Auto split

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Enums/VideoQuality.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace TwitchLeecher.Core.Enums
+{
+    public enum VideoQuality
+    {
+        [Description("Source"), Descriptor(fps: -1, resolutionY: -1)] Source,
+        [Description("1440p60"), Descriptor(fps: 60, resolutionY: 1440)] q1440f60,
+        [Description("1440p30"), Descriptor(fps: 30, resolutionY: 1440)] q1440f30,
+        [Description("1080p60"), Descriptor(fps: 60, resolutionY: 1080)] q1080f60,
+        [Description("1080p30"), Descriptor(fps: 30, resolutionY: 1080)] q1080f30,
+        [Description("900p60"), Descriptor(fps: 60, resolutionY: 900)] q900f60,
+        [Description("900p30"), Descriptor(fps: 30, resolutionY: 900)] q900f30,
+        [Description("720p60"), Descriptor(fps: 60, resolutionY: 720)] q720f60,
+        [Description("720p30"), Descriptor(fps: 30, resolutionY: 720)] q720f30,
+        //[Description("480p60"), Descriptor(fps: 60, resolutionY: 480)] q480f60,
+        [Description("480p30"), Descriptor(fps: 30, resolutionY: 480)] q480f30,
+        //[Description("360p60"), Descriptor(fps: 60, resolutionY: 360)] q360f60,
+        [Description("360p30"), Descriptor(fps: 30, resolutionY: 360)] q360f30,
+        //[Description("160p60"), Descriptor(fps: 60, resolutionY: 160)] q160p60,
+        [Description("160p30"), Descriptor(fps: 30, resolutionY: 160)] q160f30,
+        [Description("Audio only"), Descriptor(fps: 0, resolutionY: 0)] AudioOnly
+    }
+
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class DescriptorAttribute : Attribute
+    {
+        public int FPS { get; }
+        public int ResolutionY { get; }
+
+        public DescriptorAttribute(int fps, int resolutionY)
+        {
+            FPS = fps;
+            ResolutionY = resolutionY;
+        }
+    }
+
+    public static partial class GlobalMethods
+    {
+        public static int GetFps(this VideoQuality item)
+        {
+            Type type = item.GetType();
+            string itemName = Enum.GetName(type, item);
+            if (itemName != null)
+            {
+                System.Reflection.FieldInfo itemField = type.GetField(itemName);
+                if (itemField != null)
+                {
+                    if (Attribute.GetCustomAttribute(itemField, typeof(DescriptorAttribute)) is DescriptorAttribute attr)
+                    {
+                        return attr.FPS;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        public static int GetResolutionY(this VideoQuality item)
+        {
+            Type type = item.GetType();
+            string itemName = Enum.GetName(type, item);
+            if (itemName != null)
+            {
+                System.Reflection.FieldInfo itemField = type.GetField(itemName);
+                if (itemField != null)
+                {
+                    if (Attribute.GetCustomAttribute(itemField, typeof(DescriptorAttribute)) is DescriptorAttribute attr)
+                    {
+                        return attr.ResolutionY;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        public static string GetDescription(this VideoQuality value)
+        {
+            Type type = value.GetType();
+            string Name = Enum.GetName(type, value);
+            if (Name != null)
+            {
+                System.Reflection.FieldInfo field = type.GetField(Name);
+                if (field != null)
+                {
+                    if (Attribute.GetCustomAttribute(field, typeof(DescriptionAttribute)) is DescriptionAttribute attr)
+                    {
+                        return attr.Description;
+                    }
+                }
+            }
+            return value.ToString();
+        }
+
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -42,9 +42,11 @@ namespace TwitchLeecher.Core.Models
             }
 
             _video = video ?? throw new ArgumentNullException(nameof(video));
-            _quality = quality ?? throw new ArgumentNullException(nameof(quality));
             _vodAuthInfo = vodAuthInfo ?? throw new ArgumentNullException(nameof(vodAuthInfo));
 
+            //null mean that user should manually select quality. Don't worry, validation check will mark this issue
+            _quality = quality;// ?? throw new ArgumentNullException(nameof(quality));
+            
             _folder = folder;
             _filename = filename;
             _disableConversion = disableConversion;

--- a/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/DownloadParameters.cs
@@ -205,11 +205,14 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        public string CroppedLengthStr
+        public string VideoLengthStr
         {
             get
             {
-                return CroppedLength.ToDaylessString();
+                if (_cropStart || _cropEnd)
+                    return $"{CroppedLength.ToDaylessString()} ({(_cropStart ? _cropStartTime.ToDaylessString() : "00:00:00")} - {(_cropEnd ? _cropEndTime.ToDaylessString() : Video.Length.ToDaylessString())})";
+                else
+                    return CroppedLength.ToDaylessString();
             }
         }
 

--- a/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
@@ -12,6 +12,12 @@
 
         public static string TIME24 = "{time24}";
 
+        public static string DATE_ = "{date-}";
+
+        public static string TIME_ = "{time-}";
+
+        public static string TIME24_ = "{time24-}";
+
         public static string TITLE = "{title}";
 
         public static string RES = "{res}";

--- a/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/FilenameWildcards.cs
@@ -2,6 +2,8 @@
 {
     public static class FilenameWildcards
     {
+        public delegate bool IsFileNameUsedsDelegate(string fileName);
+
         public static string CHANNEL = "{channel}";
 
         public static string GAME = "{game}";
@@ -29,5 +31,7 @@
         public static string START = "{start}";
 
         public static string END = "{end}";
+
+        public static string UNIQNUMBER = "{unumber}";
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/Preferences.cs
@@ -37,6 +37,8 @@ namespace TwitchLeecher.Core.Models
 
         private string _downloadFileName;
 
+        private VideoQuality _downloadQuality;
+
         private bool _downloadSubfoldersForFav;
 
         private bool _downloadRemoveCompleted;
@@ -233,6 +235,18 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
+        public VideoQuality DownloadQuality
+        {
+            get
+            {
+                return _downloadQuality;
+            }
+            set
+            {
+                SetProperty(ref _downloadQuality, value);
+            }
+        }
+
         public bool DownloadSubfoldersForFav
         {
             get
@@ -383,6 +397,7 @@ namespace TwitchLeecher.Core.Models
                 DownloadTempFolder = DownloadTempFolder,
                 DownloadFolder = DownloadFolder,
                 DownloadFileName = DownloadFileName,
+                DownloadQuality = DownloadQuality,
                 DownloadSubfoldersForFav = DownloadSubfoldersForFav,
                 DownloadRemoveCompleted = DownloadRemoveCompleted,
                 DownloadDisableConversion = DownloadDisableConversion
@@ -392,7 +407,6 @@ namespace TwitchLeecher.Core.Models
 
             return clone;
         }
-
         #endregion Methods
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
@@ -109,5 +109,31 @@ namespace TwitchLeecher.Core.Models
         public Uri Url { get; }
 
         #endregion Properties
+
+        #region Static Methods
+
+        public static List<Tuple<TimeSpan?, TimeSpan?>> GetListOfSplitTimes(TimeSpan videoLength, TimeSpan? startCrop, TimeSpan? endCrop, TimeSpan splitTime, int overlapSec)
+        {
+            endCrop = endCrop ?? videoLength;
+            List<Tuple<TimeSpan?, TimeSpan?>> result = new List<Tuple<TimeSpan?, TimeSpan?>>();
+
+            TimeSpan? curStart = startCrop;// ?? TimeSpan.Zero;
+            TimeSpan curEnd = (curStart ?? TimeSpan.Zero).Add(splitTime.Add(new TimeSpan(0, 0, overlapSec)));
+            while (curEnd < endCrop.Value)
+            {
+                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, curEnd));
+                curStart = curEnd.Add(new TimeSpan(0, 0, -overlapSec));
+                curEnd = curEnd.Add(splitTime);
+            }
+            if (endCrop.Value.TotalSeconds - (curStart?.TotalSeconds ?? 0) < Preferences.MinSplitLength && result.Count > 0)
+            {//Add remaining seconds to last part
+                result[result.Count - 1] = new Tuple<TimeSpan?, TimeSpan?>(result[result.Count - 1].Item1, endCrop == videoLength ? null : endCrop);
+            }
+            else//or add new last part
+                result.Add(new Tuple<TimeSpan?, TimeSpan?>(curStart, endCrop == videoLength ? null : endCrop));
+            return result;
+        }
+
+        #endregion Static Methods
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideoQuality.cs
@@ -43,6 +43,8 @@ namespace TwitchLeecher.Core.Models
 
         public string Resolution { get; private set; }
 
+        public int? ResolutionY { get; private set; }
+
         public int? Fps { get; private set; }
 
         #endregion Properties
@@ -53,7 +55,8 @@ namespace TwitchLeecher.Core.Models
         {
             QualityId = qualityId;
             QualityString = GetQualityString(qualityId);
-            Resolution = GetResolution(qualityId, resolution);
+            Resolution = GetResolution(qualityId, resolution, out int? _resolutionY);
+            ResolutionY = _resolutionY;
             Fps = GetFps(qualityId, fps);
 
             if (qualityId == QUALITY_AUDIO)
@@ -90,7 +93,7 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        public string GetQualityString(string qualityId)
+        static public string GetQualityString(string qualityId)
         {
             switch (qualityId)
             {
@@ -117,8 +120,9 @@ namespace TwitchLeecher.Core.Models
             }
         }
 
-        private string GetResolution(string qualityId, string resolution)
+        private string GetResolution(string qualityId, string resolution, out int? resolutionY)
         {
+            resolutionY = null;
             if (!string.IsNullOrWhiteSpace(resolution))
             {
                 if (resolution.Equals("0x0", StringComparison.OrdinalIgnoreCase))
@@ -126,20 +130,28 @@ namespace TwitchLeecher.Core.Models
                     switch (qualityId)
                     {
                         case QUALITY_HIGH:
+                            resolutionY = 720;
                             return "1280x720";
 
                         case QUALITY_MEDIUM:
+                            resolutionY = 480;
                             return "852x480";
 
                         case QUALITY_LOW:
+                            resolutionY = 360;
                             return "640x360";
 
                         case QUALITY_MOBILE:
+                            resolutionY = 160;
                             return "284x160";
                     }
                 }
                 else
                 {
+                    //System.Text.RegularExpressions.Regex parseResolition = new System.Text.RegularExpressions.Regex(@"^(?<x>\d+)x(?<y>\d+)$");
+                    var match = System.Text.RegularExpressions.Regex.Match(resolution, @"^(?<x>\d+)x(?<y>\d+)$");
+                    //resolutionX = match.Success ? (int?)int.Parse(match.Groups["x"].Value) : null;
+                    resolutionY = match.Success ? (int?)int.Parse(match.Groups["y"].Value) : null;
                     return resolution;
                 }
             }

--- a/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
+++ b/TwitchLeecher/TwitchLeecher.Core/TwitchLeecher.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Enums\DownloadState.cs" />
     <Compile Include="Enums\LoadLimitType.cs" />
     <Compile Include="Enums\SearchType.cs" />
+    <Compile Include="Enums\VideoQuality.cs" />
     <Compile Include="Enums\VideoType.cs" />
     <Compile Include="Events\DownloadsCountChangedEvent.cs" />
     <Compile Include="Events\IsAuthorizedChangedEvent.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/Converters/VideoQualityToTextConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using TwitchLeecher.Core.Enums;
+
+namespace TwitchLeecher.Gui.Converters
+{
+    public class VideoQualityToTextConverter : IValueConverter
+    {
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is VideoQuality valueEnum)
+            {
+                return valueEnum.GetDescription();
+            }
+            else if (value is VideoQuality[] valueEnumArray)
+            {
+                string[] resultArray = new string[valueEnumArray.Length];
+                for(int index = 0;index< valueEnumArray.Length;index++)
+                    resultArray[index] = valueEnumArray[index].GetDescription();
+                return resultArray;
+            }
+            else
+            { 
+                throw new ApplicationException("Value has to be of type '" + typeof(VideoQuality).FullName + "'!");
+            }
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            VideoQuality[] allValues = (VideoQuality[])Enum.GetValues(typeof(VideoQuality));
+            foreach (VideoQuality enumVal in allValues)
+                if (enumVal.GetDescription().Equals(value))
+                    return enumVal;
+            return VideoQuality.Source;
+            //throw new NotSupportedException("This converter can only convert!");
+        }
+        #endregion IValueConverter Members
+    }
+}

--- a/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
+++ b/TwitchLeecher/TwitchLeecher.Gui/TwitchLeecher.Gui.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Converters\InverseBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\SearchTypeToBooleanConverter.cs" />
     <Compile Include="Converters\LoadLimitToBooleanConverter.cs" />
+    <Compile Include="Converters\VideoQualityToTextConverter.cs" />
     <Compile Include="Events\ShowViewEvent.cs" />
     <Compile Include="Extensions\Icon.cs" />
     <Compile Include="Interfaces\IDonationService.cs" />

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
@@ -274,13 +274,18 @@ namespace TwitchLeecher.Gui.ViewModels
         private void UpdateFilenameFromTemplate()
         {
             Preferences currentPrefs = _preferencesService.CurrentPreferences.Clone();
+            string folder = currentPrefs.DownloadFolder;
+            string fileName = currentPrefs.DownloadFileName;
 
             TimeSpan? cropStartTime = _downloadParams.CropStart ? _downloadParams.CropStartTime : TimeSpan.Zero;
             TimeSpan? cropEndTime = _downloadParams.CropEnd ? _downloadParams.CropEndTime : _downloadParams.Video.Length;
 
-            string fileName = _filenameService.SubstituteWildcards(currentPrefs.DownloadFileName, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
             fileName = _filenameService.EnsureExtension(fileName, currentPrefs.DownloadDisableConversion);
 
+            fileName = _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
+
+            _downloadParams.Filename = fileName;
+            
             _downloadParams.Filename = fileName;
         }
 

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/DownloadViewVM.cs
@@ -109,6 +109,7 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropStartHours));
                 FirePropertyChanged(nameof(CropStartMinutes));
                 FirePropertyChanged(nameof(CropStartSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
 
@@ -126,6 +127,7 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropStartHours));
                 FirePropertyChanged(nameof(CropStartMinutes));
                 FirePropertyChanged(nameof(CropStartSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
 
@@ -143,6 +145,7 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropStartHours));
                 FirePropertyChanged(nameof(CropStartMinutes));
                 FirePropertyChanged(nameof(CropStartSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
 
@@ -160,6 +163,7 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropEndHours));
                 FirePropertyChanged(nameof(CropEndMinutes));
                 FirePropertyChanged(nameof(CropEndSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
 
@@ -177,6 +181,7 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropEndHours));
                 FirePropertyChanged(nameof(CropEndMinutes));
                 FirePropertyChanged(nameof(CropEndSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
 
@@ -194,8 +199,106 @@ namespace TwitchLeecher.Gui.ViewModels
                 FirePropertyChanged(nameof(CropEndHours));
                 FirePropertyChanged(nameof(CropEndMinutes));
                 FirePropertyChanged(nameof(CropEndSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
             }
         }
+
+        public bool AutoSplitUseExtended
+        {
+            get
+            {
+                return _downloadParams.AutoSplit;
+            }
+            set
+            {
+                if (value != _downloadParams.AutoSplit)
+                {
+                    _downloadParams.AutoSplit = value;
+                    if (!UseCustomFilename)
+                        UpdateFilenameFromTemplate();
+                    else
+                    {
+                        if (_downloadParams.AutoSplit && !_downloadParams.Filename.Contains(FilenameWildcards.UNIQNUMBER))
+                        {//Add _{unumber} before extension
+                            _downloadParams.Filename = _downloadParams.Filename.Insert(_downloadParams.Filename.Length - Path.GetExtension(_downloadParams.Filename).Length, $"_{FilenameWildcards.UNIQNUMBER}");
+                        }
+                        else if (!_downloadParams.AutoSplit)
+                        {
+                            string searchStr = $"_{FilenameWildcards.UNIQNUMBER}{Path.GetExtension(_downloadParams.Filename)}";
+                            if (_downloadParams.Filename.EndsWith(searchStr))
+                            {//remove _{unumber} from end of filename
+                                _downloadParams.Filename = _downloadParams.Filename.Remove(_downloadParams.Filename.Length - searchStr.Length, searchStr.Length - Path.GetExtension(_downloadParams.Filename).Length);
+                            }
+                        }
+                    }
+                    FirePropertyChanged(nameof(AutoSplitUseExtended));
+                }
+            }
+        }
+
+        public int AutoSplitTimeHours
+        {
+            get
+            {
+                return _downloadParams.AutoSplitTime.GetDaysInHours();
+            }
+            set
+            {
+                TimeSpan current = _downloadParams.AutoSplitTime;
+                _downloadParams.AutoSplitTime = new TimeSpan(value, current.Minutes, current.Seconds);
+
+                FirePropertyChanged(nameof(AutoSplitTimeHours));
+                FirePropertyChanged(nameof(AutoSplitTimeMinutes));
+                FirePropertyChanged(nameof(AutoSplitTimeSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
+            }
+        }
+
+        public int AutoSplitTimeMinutes
+        {
+            get
+            {
+                return _downloadParams.AutoSplitTime.Minutes;
+            }
+            set
+            {
+                TimeSpan current = _downloadParams.AutoSplitTime;
+                _downloadParams.AutoSplitTime = new TimeSpan(current.GetDaysInHours(), value, current.Seconds);
+
+                FirePropertyChanged(nameof(AutoSplitTimeHours));
+                FirePropertyChanged(nameof(AutoSplitTimeMinutes));
+                FirePropertyChanged(nameof(AutoSplitTimeSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
+            }
+        }
+
+        public int AutoSplitTimeSeconds
+        {
+            get
+            {
+                return _downloadParams.AutoSplitTime.Seconds;
+            }
+            set
+            {
+                TimeSpan current = _downloadParams.AutoSplitTime;
+                _downloadParams.AutoSplitTime = new TimeSpan(current.GetDaysInHours(), current.Minutes, value);
+
+                FirePropertyChanged(nameof(AutoSplitTimeHours));
+                FirePropertyChanged(nameof(AutoSplitTimeMinutes));
+                FirePropertyChanged(nameof(AutoSplitTimeSeconds));
+                FirePropertyChanged(nameof(AutoSplitPartCount));
+            }
+        }
+
+        public int AutoSplitPartCount
+        {
+            get
+            {
+                if (_downloadParams.AutoSplit == false || DownloadParams.AutoSplitTime.TotalSeconds < Preferences.MinSplitLength || DownloadParams.CroppedLength.TotalSeconds < Preferences.MinSplitLength)
+                    return 1;
+                return Math.Max((int)Math.Ceiling((DownloadParams.CroppedLength.TotalSeconds - Preferences.MinSplitLength) / DownloadParams.AutoSplitTime.TotalSeconds), 1);
+            }
+         }
 
         public ICommand ChooseCommand
         {
@@ -281,12 +384,25 @@ namespace TwitchLeecher.Gui.ViewModels
             TimeSpan? cropEndTime = _downloadParams.CropEnd ? _downloadParams.CropEndTime : _downloadParams.Video.Length;
 
             fileName = _filenameService.EnsureExtension(fileName, currentPrefs.DownloadDisableConversion);
+            //if (AutoSplitUseExtended && currentPrefs.DownloadDisableConversion)
+            //    AutoSplitUseExtended = false;
 
-            fileName = _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
+            if (AutoSplitUseExtended && fileName.Contains(FilenameWildcards.UNIQNUMBER))
+            {
+                string tempUniqNumb = FilenameWildcards.UNIQNUMBER.Insert(FilenameWildcards.UNIQNUMBER.Length - 1, "_temp");
+                fileName = fileName.Replace(FilenameWildcards.UNIQNUMBER, tempUniqNumb);
+                fileName = _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
+                fileName = fileName.Replace(tempUniqNumb, FilenameWildcards.UNIQNUMBER);
+            }
+            else
+                fileName = _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
 
             _downloadParams.Filename = fileName;
-            
-            _downloadParams.Filename = fileName;
+        }
+
+        private string GetFilenameFromTemplate(string fileName, string folder, TimeSpan? cropStartTime = null, TimeSpan? cropEndTime = null)
+        {
+            return _filenameService.SubstituteWildcards(fileName, folder, _twitchService.IsFileNameUsed, _downloadParams.Video, _downloadParams.Quality, cropStartTime, cropEndTime);
         }
 
         private void Download()
@@ -297,21 +413,63 @@ namespace TwitchLeecher.Gui.ViewModels
                 {
                     Validate();
 
+                    //if (!HasErrors)
+                    //{
+                    //    if (File.Exists(_downloadParams.FullPath))
+                    //    {
+                    //        MessageBoxResult result = _dialogService.ShowMessageBox("The file already exists. Do you want to overwrite it?", "Download", MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+                    //        if (result != MessageBoxResult.Yes)
+                    //        {
+                    //            return;
+                    //        }
+                    //    }
+
+                    //    _twitchService.Enqueue(_downloadParams);
+                    //    _navigationService.NavigateBack();
+                    //    _notificationService.ShowNotification("Download added");
+                    //}
                     if (!HasErrors)
                     {
-                        if (File.Exists(_downloadParams.FullPath))
+                        int downloadAddedCount = 1;
+                        if (_downloadParams.AutoSplit && _downloadParams.AutoSplitTime.TotalSeconds > Preferences.MinSplitLength)
                         {
-                            MessageBoxResult result = _dialogService.ShowMessageBox("The file already exists. Do you want to overwrite it?", "Download", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                            string baseFolder = Path.GetDirectoryName(_downloadParams.FullPath);
+                            string baseFilename = Path.GetFileName(_downloadParams.FullPath);
 
-                            if (result != MessageBoxResult.Yes)
+                            var splitTimes = TwitchVideo.GetListOfSplitTimes(_downloadParams.Video.Length, _downloadParams.CropStart ? (TimeSpan?)_downloadParams.CropStartTime : null, _downloadParams.CropEnd ? (TimeSpan?)_downloadParams.CropEndTime : null, _downloadParams.AutoSplitTime, _downloadParams.AutoSplitOverlap);
+                            foreach(var splitPair in splitTimes)
                             {
-                                return;
+                                string filename = GetFilenameFromTemplate(baseFilename, baseFolder, splitPair.Item1, splitPair.Item2);
+                                DownloadParameters tempParams = new DownloadParameters(_downloadParams.Video, _downloadParams.VodAuthInfo, _downloadParams.Quality, baseFolder, filename, _downloadParams.DisableConversion, false, new TimeSpan(), 0);
+                                tempParams.AutoSplit = false;
+                                tempParams.CropStart = splitPair.Item1.HasValue;
+                                tempParams.CropStartTime = splitPair.Item1 ?? new TimeSpan();
+                                tempParams.CropEnd = splitPair.Item2.HasValue;
+                                tempParams.CropEndTime = splitPair.Item2 ?? _downloadParams.Video.Length;
+                                _twitchService.Enqueue(tempParams);
                             }
+                            downloadAddedCount = splitTimes.Count;
                         }
+                        else
+                        {
+                            if (File.Exists(_downloadParams.FullPath))
+                            {
+                                MessageBoxResult result = _dialogService.ShowMessageBox("The file already exists. Do you want to overwrite it?", "Download", MessageBoxButton.YesNo, MessageBoxImage.Question);
 
-                        _twitchService.Enqueue(_downloadParams);
+                                if (result != MessageBoxResult.Yes)
+                                {
+                                    return;
+                                }
+                            }
+
+                            _twitchService.Enqueue(_downloadParams);
+                        }
                         _navigationService.NavigateBack();
-                        _notificationService.ShowNotification("Download added");
+                        if (downloadAddedCount <= 1)
+                            _notificationService.ShowNotification("Download added");
+                        else
+                            _notificationService.ShowNotification($"{downloadAddedCount} downloads added");
                     }
                 }
             }
@@ -369,6 +527,21 @@ namespace TwitchLeecher.Gui.ViewModels
                         AddError(nameof(CropEndHours), firstError);
                         AddError(nameof(CropEndMinutes), firstError);
                         AddError(nameof(CropEndSeconds), firstError);
+                    }
+
+                    if (DownloadParams.GetErrors(nameof(DownloadParameters.AutoSplitTime)) is List<string> autoSplitTimeErrors && autoSplitTimeErrors.Count > 0)
+                    {
+                        string firstError = autoSplitTimeErrors.First();
+                        AddError(nameof(AutoSplitTimeHours), firstError);
+                        AddError(nameof(AutoSplitTimeMinutes), firstError);
+                        AddError(nameof(AutoSplitTimeSeconds), firstError);
+                        AddError(nameof(AutoSplitUseExtended), firstError);
+                    }
+
+                    if (DownloadParams.GetErrors(nameof(DownloadParameters.AutoSplitOverlap)) is List<string> overlapErrors && overlapErrors.Count > 0)
+                    {
+                        string firstError = overlapErrors.First();
+                        AddError(nameof(AutoSplitUseExtended), firstError);
                     }
                 }
             }

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/PreferencesViewVM.cs
@@ -188,6 +188,56 @@ namespace TwitchLeecher.Gui.ViewModels
             }
         }
 
+        public int DownloadSplitTimeHours
+        {
+            get
+            {
+                return (int) CurrentPreferences.DownloadSplitTime.TotalHours;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan(value, current.Minutes, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeMinutes
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Minutes;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int) CurrentPreferences.DownloadSplitTime.TotalHours, value, current.Seconds);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
+
+        public int DownloadSplitTimeSeconds
+        {
+            get
+            {
+                return CurrentPreferences.DownloadSplitTime.Seconds;
+            }
+            set
+            {
+                TimeSpan current = CurrentPreferences.DownloadSplitTime;
+                CurrentPreferences.DownloadSplitTime = new TimeSpan((int) CurrentPreferences.DownloadSplitTime.TotalHours, current.Minutes, value);
+
+                FirePropertyChanged(nameof(DownloadSplitTimeHours));
+                FirePropertyChanged(nameof(DownloadSplitTimeMinutes));
+                FirePropertyChanged(nameof(DownloadSplitTimeSeconds));
+            }
+        }
         #endregion Properties
 
         #region Methods
@@ -432,6 +482,14 @@ namespace TwitchLeecher.Gui.ViewModels
                 if (CurrentPreferences.HasErrors)
                 {
                     AddError(currentProperty, "Invalid Preferences!");
+
+                    if (CurrentPreferences.GetErrors(nameof(CurrentPreferences.DownloadSplitTime)) is List<string> downloadSplitTimeErrors && downloadSplitTimeErrors.Count > 0)
+                    {
+                        string firstError = downloadSplitTimeErrors.First();
+                        AddError(nameof(DownloadSplitTimeHours), firstError);
+                        AddError(nameof(DownloadSplitTimeMinutes), firstError);
+                        AddError(nameof(DownloadSplitTimeSeconds), firstError);
+                    }
                 }
             }
         }

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
@@ -195,8 +195,9 @@ namespace TwitchLeecher.Gui.ViewModels
                                 ? Path.Combine(currentPrefs.DownloadFolder, video.Channel)
                                 : currentPrefs.DownloadFolder;
 
-                            string filename = _filenameService.SubstituteWildcards(currentPrefs.DownloadFileName, video);
+                            string filename = currentPrefs.DownloadFileName;
                             filename = _filenameService.EnsureExtension(filename, currentPrefs.DownloadDisableConversion);
+                            filename = _filenameService.SubstituteWildcards(filename, folder, _twitchService.IsFileNameUsed, video);
 
                             TwitchVideoQuality shouldQualityOrNull = TryFindQuality(video.Qualities, currentPrefs.DownloadQuality);
 

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadView.xaml
@@ -106,6 +106,9 @@
                         <RowDefinition SharedSizeGroup="g2" />
                         <RowDefinition Height="5" />
                         <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition Height="5" />
+                        <RowDefinition SharedSizeGroup="g2" />
+                        <RowDefinition SharedSizeGroup="g2" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -119,21 +122,37 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="3" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="12" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
                     <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding DownloadParams.CropStart}" Content="Start" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" Maximum="99" Loop="False" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" Maximum="99" Loop="False" />
                     <TextBlock Grid.Row="0" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" />
                     <TextBlock Grid.Row="0" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropStart}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="0" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropStartSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropStart}" />
 
                     <CheckBox Grid.Row="2" Grid.Column="0" IsChecked="{Binding  DownloadParams.CropEnd}" Content="End" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" Maximum="99" Loop="False" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" Maximum="99" Loop="False" />
                     <TextBlock Grid.Row="2" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" />
                     <TextBlock Grid.Row="2" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
-                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+                    <ctrl:TlIntegerUpDown Grid.Row="2" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding CropEndSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.CropEnd}" />
+
+                    <CheckBox Grid.Row="4" Grid.Column="0" IsChecked="{Binding AutoSplitUseExtended}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeHours, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Row="4" Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeMinutes, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+                    <TextBlock Grid.Row="4" Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding AutoSplitTimeSeconds, UpdateSourceTrigger=PropertyChanged}" IsEnabled="{Binding DownloadParams.AutoSplit}" />
+                    <TextBlock Grid.Row="4" Grid.Column="12"  Text="Overlap" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Row="4" Grid.Column="14" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadParams.AutoSplitOverlap, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding DownloadParams.AutoSplit}" Maximum="99"/>
+                    
+                    <TextBlock Grid.Row="5" Grid.Column="2" Grid.ColumnSpan="9" Text="{Binding AutoSplitPartCount, StringFormat='Video parts: {0}', FallbackValue='Video count: 1'}" VerticalAlignment="Center" HorizontalAlignment="Center" 
+                               Visibility="{Binding AutoSplitUseExtended, Converter={StaticResource ResourceKey='BVConverter'}}"/>
                 </Grid>
             </Grid>
         </Grid>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/DownloadsView.xaml
@@ -27,7 +27,7 @@
                                 </fa:ImageAwesome.Foreground>
                             </fa:ImageAwesome>
                         </StackPanel>
-                    </DataTemplate>
+                    </DataTemplate> 
 
                     <Style x:Key="thisStyle" TargetType="{x:Type UserControl}">
                         <Style.Triggers>
@@ -156,6 +156,8 @@
                                         <RowDefinition SharedSizeGroup="g1" />
                                         <RowDefinition Height="10" />
                                         <RowDefinition SharedSizeGroup="g1" />
+                                        <RowDefinition Height="10" />
+                                        <RowDefinition SharedSizeGroup="g1" />
                                     </Grid.RowDefinitions>
 
                                     <TextBlock Grid.Column="0" Grid.Row="0" Text="Status:" FontWeight="Bold" />
@@ -169,13 +171,16 @@
                                     <TextBlock Grid.Column="2" Grid.Row="2" Text="{Binding DownloadParams.Video.Game}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="4" Text="Length:" FontWeight="Bold" />
-                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.CroppedLengthStr}" />
+                                    <TextBlock Grid.Column="2" Grid.Row="4" Text="{Binding DownloadParams.VideoLengthStr}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="6" Text="Recorded:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="6" Text="{Binding DownloadParams.Video.RecordedDate, StringFormat=G}" />
 
                                     <TextBlock Grid.Column="0" Grid.Row="8" Text="Quality:" FontWeight="Bold" />
                                     <TextBlock Grid.Column="2" Grid.Row="8" Text="{Binding DownloadParams.Quality.DisplayString}" />
+
+                                    <TextBlock Grid.Column="0" Grid.Row="10" Text="File name:" FontWeight="Bold" />
+                                    <TextBlock Grid.Column="2" Grid.Row="10" Text="{Binding DownloadParams.FullPath}" />
                                 </Grid>
                             </Grid>
                             <Border Grid.Row="2" BorderThickness="0,1,0,0" Padding="0,10,0,0" Margin="0,10,0,0">

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -313,6 +313,12 @@
                                         <RowDefinition SharedSizeGroup="r2" />
                                         <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -338,37 +344,49 @@
                                     <TextBlock Grid.Row="6" Grid.Column="2" Text="Recording date (yyyyMMdd)" />
                                     <TextBlock Grid.Row="6" Grid.Column="4" Text="20160418" />
 
-                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{time}" />
-                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording time" />
-                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="034622PM" />
+                                    <TextBlock Grid.Row="8" Grid.Column="0" Text="{}{date-}" />
+                                    <TextBlock Grid.Row="8" Grid.Column="2" Text="Recording date (yyyy-MM-dd)" />
+                                    <TextBlock Grid.Row="8" Grid.Column="4" Text="2016-04-18" />
 
-                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time24}" />
-                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time (24 hours)" />
-                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="174622" />
+                                    <TextBlock Grid.Row="10" Grid.Column="0" Text="{}{time}" />
+                                    <TextBlock Grid.Row="10" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="10" Grid.Column="4" Text="034622PM" />
 
-                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{id}" />
-                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Twitch video ID" />
-                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="54869708" />
+                                    <TextBlock Grid.Row="12" Grid.Column="0" Text="{}{time-}" />
+                                    <TextBlock Grid.Row="12" Grid.Column="2" Text="Recording time" />
+                                    <TextBlock Grid.Row="12" Grid.Column="4" Text="03-46-22_PM" />
 
-                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{title}" />
-                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Video Title" />
-                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="Best Strim Evr!!!" />
+                                    <TextBlock Grid.Row="14" Grid.Column="0" Text="{}{time24}" />
+                                    <TextBlock Grid.Row="14" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="14" Grid.Column="4" Text="174622" />
 
-                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{res}" />
-                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Video Resolution" />
-                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="1280x720" />
+                                    <TextBlock Grid.Row="16" Grid.Column="0" Text="{}{time24-}" />
+                                    <TextBlock Grid.Row="16" Grid.Column="2" Text="Recording time (24 hours)" />
+                                    <TextBlock Grid.Row="16" Grid.Column="4" Text="17-46-22" />
 
-                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{fps}" />
-                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Video Framerate" />
-                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="60" />
+                                    <TextBlock Grid.Row="18" Grid.Column="0" Text="{}{id}" />
+                                    <TextBlock Grid.Row="18" Grid.Column="2" Text="Twitch video ID" />
+                                    <TextBlock Grid.Row="18" Grid.Column="4" Text="54869708" />
 
-                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{start}" />
-                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Crop start time (HHmmss)" />
-                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="012744" />
+                                    <TextBlock Grid.Row="20" Grid.Column="0" Text="{}{title}" />
+                                    <TextBlock Grid.Row="20" Grid.Column="2" Text="Video Title" />
+                                    <TextBlock Grid.Row="20" Grid.Column="4" Text="Best Strim Evr!!!" />
 
-                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{end}" />
-                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Crop end time (HHmmss)" />
-                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="025317" />
+                                    <TextBlock Grid.Row="22" Grid.Column="0" Text="{}{res}" />
+                                    <TextBlock Grid.Row="22" Grid.Column="2" Text="Video Resolution" />
+                                    <TextBlock Grid.Row="22" Grid.Column="4" Text="1280x720" />
+
+                                    <TextBlock Grid.Row="24" Grid.Column="0" Text="{}{fps}" />
+                                    <TextBlock Grid.Row="24" Grid.Column="2" Text="Video Framerate" />
+                                    <TextBlock Grid.Row="24" Grid.Column="4" Text="60" />
+
+                                    <TextBlock Grid.Row="26" Grid.Column="0" Text="{}{start}" />
+                                    <TextBlock Grid.Row="26" Grid.Column="2" Text="Crop start time (HHmmss)" />
+                                    <TextBlock Grid.Row="26" Grid.Column="4" Text="012744" />
+
+                                    <TextBlock Grid.Row="28" Grid.Column="0" Text="{}{end}" />
+                                    <TextBlock Grid.Row="28" Grid.Column="2" Text="Crop end time (HHmmss)" />
+                                    <TextBlock Grid.Row="28" Grid.Column="4" Text="025317" />
                                 </Grid>
                             </StackPanel>
                         </ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
              xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
              xmlns:enums="clr-namespace:TwitchLeecher.Core.Enums;assembly=TwitchLeecher.Core"
+             xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -14,6 +15,7 @@
                 <ResourceDictionary Source="../Theme/Images.xaml" />
                 <ResourceDictionary>
                     <converters:VideoTypeToBooleanConverter x:Key="videoTypeToBooleanConverter" />
+                    <converters:VideoQualityToTextConverter x:Key="videoQualityToTextConverter" />
                     <converters:LoadLimitToBooleanConverter x:Key="loadLimitToBooleanConverter" />
                     <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
                 </ResourceDictionary>
@@ -211,7 +213,17 @@
             </Border>
 
             <Grid Grid.Row="5" Margin="15,0,0,0">
+                <Grid.Resources>
+                    <ObjectDataProvider x:Key="dataFromEnum" MethodName="GetValues"
+                        ObjectType="{x:Type System:Enum}">
+                        <ObjectDataProvider.MethodParameters>
+                            <x:Type TypeName="enums:VideoQuality"/>
+                        </ObjectDataProvider.MethodParameters>
+                    </ObjectDataProvider>
+                </Grid.Resources>
                 <Grid.RowDefinitions>
+                    <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
@@ -392,9 +404,24 @@
                         </ToolTip>
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
-
-                <CheckBox Grid.Row="6" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                
+                <TextBlock Grid.Row="6" Grid.Column="0" Text="Quality by default" VerticalAlignment="Center" />
+                <ComboBox Grid.Row="6" Grid.Column="2" VerticalAlignment="Center" ItemsSource="{Binding Source={StaticResource dataFromEnum}, Converter={StaticResource videoQualityToTextConverter}}" SelectedItem="{Binding CurrentPreferences.DownloadQuality, Converter={StaticResource videoQualityToTextConverter}}"/>
                 <fa:ImageAwesome Grid.Row="6" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip  Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Quality by default" />
+                                <TextBlock TextAlignment="Justify">
+                                    Specify quality that will be select for download by default. If there are no selected quality, it will be empty and you will have to select it manually.
+                                </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+
+                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadSubfoldersForFav}" Content="Create subfolders for favourite channels" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -407,8 +434,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="8" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="8" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadRemoveCompleted}" Content="Remove successful downloads from queue" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>
@@ -421,8 +448,8 @@
                     </fa:ImageAwesome.ToolTip>
                 </fa:ImageAwesome>
 
-                <CheckBox Grid.Row="10" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
-                <fa:ImageAwesome Grid.Row="10" Grid.Column="4" Style="{StaticResource Img_Help}">
+                <CheckBox Grid.Row="12" Grid.Column="2" IsChecked="{Binding CurrentPreferences.DownloadDisableConversion}" Content="Disable conversion to mp4 (also disables cropping)" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <fa:ImageAwesome Grid.Row="12" Grid.Column="4" Style="{StaticResource Img_Help}">
                     <fa:ImageAwesome.ToolTip>
                         <ToolTip  Width="350">
                             <StackPanel>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -4,6 +4,7 @@
              xmlns:converters="clr-namespace:TwitchLeecher.Gui.Converters"
              xmlns:ctrl="clr-namespace:TwitchLeecher.Gui.Controls"
              xmlns:enums="clr-namespace:TwitchLeecher.Core.Enums;assembly=TwitchLeecher.Core"
+             xmlns:prefs="clr-namespace:TwitchLeecher.Core.Models;assembly=TwitchLeecher.Core"
              xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:fa="http://schemas.fontawesome.io/icons/">
     <UserControl.Resources>
@@ -18,6 +19,7 @@
                     <converters:VideoQualityToTextConverter x:Key="videoQualityToTextConverter" />
                     <converters:LoadLimitToBooleanConverter x:Key="loadLimitToBooleanConverter" />
                     <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
+                    <converters:InverseBooleanConverter x:Key="InverseBoolConverter"/>
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -419,7 +421,7 @@
                             <StackPanel>
                                 <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Quality by default" />
                                 <TextBlock TextAlignment="Justify">
-                                    Specify quality that will be select for download by default. If there are no selected quality, it will be empty and you will have to select it manually.
+                                    Specify quality that will be select for download by default. If video hasn't selected quality, you will have to select it manually.
                                 </TextBlock>
                             </StackPanel>
                         </ToolTip>
@@ -481,6 +483,8 @@
                     <RowDefinition SharedSizeGroup="r1" />
                     <RowDefinition Height="10" />
                     <RowDefinition SharedSizeGroup="r1" />
+                    <RowDefinition Height="10" />
+                    <RowDefinition SharedSizeGroup="r1" />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" SharedSizeGroup="g2" />
@@ -528,6 +532,47 @@
                                 <TextBlock TextAlignment="Justify">
                                         The external video player to use (preferably VLC because it works great with Twitch streams)
                                 </TextBlock>
+                            </StackPanel>
+                        </ToolTip>
+                    </fa:ImageAwesome.ToolTip>
+                </fa:ImageAwesome>
+                
+                <TextBlock Grid.Row="4" Grid.Column="0" Text="Auto Split" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <Grid Grid.Row="4" Grid.Column="2" Grid.IsSharedSizeScope="True" IsEnabled="{Binding CurrentPreferences.DownloadDisableConversion, Converter={StaticResource InverseBoolConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="20" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="10" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="3" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <CheckBox Grid.Column="0" IsChecked="{Binding CurrentPreferences.DownloadSplitUse}" Content="Auto" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="2" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeHours, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" Maximum="99" Loop="False" />
+                    <TextBlock Grid.Column="4"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="6" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeMinutes, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                    <TextBlock Grid.Column="8"  Text=":" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="10" Style="{StaticResource TlTimeUpDown}" Value="{Binding DownloadSplitTimeSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" />
+                    <TextBlock Grid.Column="12"  Text="Overlap" VerticalAlignment="Center" />
+                    <ctrl:TlIntegerUpDown Grid.Column="14" Style="{StaticResource TlTimeUpDown}" Value="{Binding CurrentPreferences.SplitOverlapSeconds, UpdateSourceTrigger=LostFocus}" IsEnabled="{Binding CurrentPreferences.DownloadSplitUse}" Maximum="99"/>
+                </Grid>
+                <fa:ImageAwesome Grid.Row="4" Grid.Column="4" Style="{StaticResource Img_Help}">
+                    <fa:ImageAwesome.ToolTip>
+                        <ToolTip Width="350">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TlToolTipHeadlineText}" Text="Auto Split" />
+                                <TextBlock TextAlignment="Justify" Text="{Binding Path=(prefs:Preferences.MinSplitLength), 
+                                    StringFormat='Auto split stream in part with this length. Also add extra seconds to overlap between video parts. Split time has to be at least {0} seconds, parts smaller will be attached to previous part.'}"/>
                             </StackPanel>
                         </ToolTip>
                     </fa:ImageAwesome.ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
+++ b/TwitchLeecher/TwitchLeecher.Gui/Views/PreferencesView.xaml
@@ -331,6 +331,8 @@
                                         <RowDefinition SharedSizeGroup="r2" />
                                         <RowDefinition Height="5" />
                                         <RowDefinition SharedSizeGroup="r2" />
+                                        <RowDefinition Height="5" />
+                                        <RowDefinition SharedSizeGroup="r2" />
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" />
@@ -399,6 +401,10 @@
                                     <TextBlock Grid.Row="28" Grid.Column="0" Text="{}{end}" />
                                     <TextBlock Grid.Row="28" Grid.Column="2" Text="Crop end time (HHmmss)" />
                                     <TextBlock Grid.Row="28" Grid.Column="4" Text="025317" />
+                                    
+                                    <TextBlock Grid.Row="30" Grid.Column="0" Text="{}{unumber}" />
+                                    <TextBlock Grid.Row="30" Grid.Column="2" Text="Number to avoid overwrite" />
+                                    <TextBlock Grid.Row="30" Grid.Column="4" Text="1" />
                                 </Grid>
                             </StackPanel>
                         </ToolTip>

--- a/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Interfaces/IFilenameService.cs
@@ -5,7 +5,7 @@ namespace TwitchLeecher.Services.Interfaces
 {
     public interface IFilenameService
     {
-        string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
+        string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null);
 
         string SubstituteInvalidChars(string filename, string replaceStr);
 

--- a/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
@@ -12,7 +12,7 @@ namespace TwitchLeecher.Services.Services
     {
         #region Methods
 
-        public string SubstituteWildcards(string filename, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
+        public string SubstituteWildcards(string filename, string folder, FilenameWildcards.IsFileNameUsedsDelegate IsFileNameUsed, TwitchVideo video, TwitchVideoQuality quality = null, TimeSpan? cropStart = null, TimeSpan? cropEnd = null)
         {
             if (video == null)
             {
@@ -48,6 +48,14 @@ namespace TwitchLeecher.Services.Services
             result = result.Replace(FilenameWildcards.END, selectedCropEnd.ToShortDaylessString());
 
             result = SubstituteInvalidChars(result, "_");
+
+            if (result.Contains(FilenameWildcards.UNIQNUMBER))
+            {
+                int index = 1;
+                while (File.Exists(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))) || IsFileNameUsed(Path.Combine(folder, result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString()))))
+                    index++;
+                result = result.Replace(FilenameWildcards.UNIQNUMBER, index.ToString());
+            }
 
             return result;
         }

--- a/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/FilenameService.cs
@@ -37,6 +37,9 @@ namespace TwitchLeecher.Services.Services
             result = result.Replace(FilenameWildcards.DATE, recorded.ToString("yyyyMMdd"));
             result = result.Replace(FilenameWildcards.TIME, recorded.ToString("hhmmsstt", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.TIME24, recorded.ToString("HHmmss", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.DATE_, recorded.ToString("yyyy-MM-dd"));
+            result = result.Replace(FilenameWildcards.TIME_, recorded.ToString("hh-mm-ss_tt", CultureInfo.InvariantCulture));
+            result = result.Replace(FilenameWildcards.TIME24_, recorded.ToString("HH-mm-ss", CultureInfo.InvariantCulture));
             result = result.Replace(FilenameWildcards.ID, video.Id);
             result = result.Replace(FilenameWildcards.TITLE, video.Title);
             result = result.Replace(FilenameWildcards.RES, !string.IsNullOrWhiteSpace(selectedQuality.Resolution) ? selectedQuality.Resolution : TwitchVideoQuality.UNKNOWN);

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -44,6 +44,9 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_SUBFOLDERSFORFAV_EL = "SubfoldersForFav";
         private const string DOWNLOAD_REMOVECOMPLETED_EL = "RemoveCompleted";
         private const string DOWNLOAD_DISABLECONVERSION_EL = "DisableConversion";
+        private const string DOWNLOAD_SPLITUSE_EL = "SplitUse";
+        private const string DOWNLOAD_SPLITTIME_EL = "SplitTime";
+        private const string DOWNLOAD_SPLITOVERLAP_EL = "SplitOverlapSeconds";
 
         private const string MISC_EL = "Misc";
         private const string MISC_USEEXTERNALPLAYER_EL = "UseExternalPlayer";
@@ -224,6 +227,18 @@ namespace TwitchLeecher.Services.Services
                 XElement downloadDisableConversionEl = new XElement(DOWNLOAD_DISABLECONVERSION_EL);
                 downloadDisableConversionEl.SetValue(preferences.DownloadDisableConversion);
                 downloadEl.Add(downloadDisableConversionEl);
+
+                XElement downloadSplitUseEl = new XElement(DOWNLOAD_SPLITUSE_EL);
+                downloadSplitUseEl.SetValue(preferences.DownloadSplitUse);
+                downloadEl.Add(downloadSplitUseEl);
+                
+                XElement downloadSplitTimeEl = new XElement(DOWNLOAD_SPLITTIME_EL);
+                downloadSplitTimeEl.SetValue(DateTime.MinValue + preferences.DownloadSplitTime);
+                downloadEl.Add(downloadSplitTimeEl);
+
+                XElement splitOverlapSecondsEl = new XElement(DOWNLOAD_SPLITOVERLAP_EL);
+                splitOverlapSecondsEl.SetValue(preferences.SplitOverlapSeconds);
+                downloadEl.Add(splitOverlapSecondsEl);
 
                 // Miscellanious
                 XElement miscUseExternalPlayerEl = new XElement(MISC_USEEXTERNALPLAYER_EL);
@@ -534,6 +549,48 @@ namespace TwitchLeecher.Services.Services
                             }
                         }
 
+                        XElement downloadSplitUseEl = downloadEl.Element(DOWNLOAD_SPLITUSE_EL);
+
+                        if (downloadSplitUseEl != null)
+                        {
+                            try
+                            {
+                                preferences.DownloadSplitUse = downloadSplitUseEl.GetValueAsBool();
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
+                        XElement downloadSplitTimeEl = downloadEl.Element(DOWNLOAD_SPLITTIME_EL);
+
+                        if (downloadSplitTimeEl != null)
+                        {
+                            try
+                            {
+                                preferences.DownloadSplitTime = downloadSplitTimeEl.GetValueAsDateTime() - DateTime.MinValue;
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
+                        XElement splitOverlapSecondsEl = downloadEl.Element(DOWNLOAD_SPLITOVERLAP_EL);
+
+                        if (splitOverlapSecondsEl != null)
+                        {
+                            try
+                            {
+                                preferences.SplitOverlapSeconds = splitOverlapSecondsEl.GetValueAsInt();
+                            }
+                            catch
+                            {
+                                // Value from config file could not be loaded, use default value
+                            }
+                        }
+
                         XElement miscEl = preferencesEl.Element(MISC_EL);
 
                         if (miscEl != null)
@@ -592,8 +649,11 @@ namespace TwitchLeecher.Services.Services
                 DownloadQuality = VideoQuality.Source,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,
+                DownloadSplitTime = new TimeSpan(),
+                DownloadSplitUse = false,
                 MiscUseExternalPlayer = false,
-                MiscExternalPlayer = null
+                MiscExternalPlayer = null,
+                SplitOverlapSeconds = 10,
             };
 
             return preferences;

--- a/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
+++ b/TwitchLeecher/TwitchLeecher.Services/Services/PreferencesService.cs
@@ -40,6 +40,7 @@ namespace TwitchLeecher.Services.Services
         private const string DOWNLOAD_TEMPFOLDER_EL = "TempFolder";
         private const string DOWNLOAD_FOLDER_EL = "Folder";
         private const string DOWNLOAD_FILENAME_EL = "FileName";
+        private const string DOWNLOAD_QUALITY_EL = "Quality";
         private const string DOWNLOAD_SUBFOLDERSFORFAV_EL = "SubfoldersForFav";
         private const string DOWNLOAD_REMOVECOMPLETED_EL = "RemoveCompleted";
         private const string DOWNLOAD_DISABLECONVERSION_EL = "DisableConversion";
@@ -207,6 +208,10 @@ namespace TwitchLeecher.Services.Services
                     downloadFileNameEl.SetValue(preferences.DownloadFileName);
                     downloadEl.Add(downloadFileNameEl);
                 }
+
+                XElement downloadQualityEl = new XElement(DOWNLOAD_QUALITY_EL);
+                downloadQualityEl.SetValue(preferences.DownloadQuality);
+                downloadEl.Add(downloadQualityEl);
 
                 XElement downloadSubfoldersForFavEl = new XElement(DOWNLOAD_SUBFOLDERSFORFAV_EL);
                 downloadSubfoldersForFavEl.SetValue(preferences.DownloadSubfoldersForFav);
@@ -472,6 +477,20 @@ namespace TwitchLeecher.Services.Services
                                 }
                             }
 
+                            XElement downloadQualityEl = downloadEl.Element(DOWNLOAD_QUALITY_EL);
+
+                            if (downloadQualityEl != null)
+                            {
+                                try
+                                {
+                                    preferences.DownloadQuality = downloadQualityEl.GetValueAsEnum<VideoQuality>();
+                                }
+                                catch
+                                {
+                                    // Value from config file could not be loaded, use default value
+                                }
+                            }
+
                             XElement donwloadSubfolderForFavEl = downloadEl.Element(DOWNLOAD_SUBFOLDERSFORFAV_EL);
 
                             if (donwloadSubfolderForFavEl != null)
@@ -570,6 +589,7 @@ namespace TwitchLeecher.Services.Services
                 DownloadTempFolder = _folderService.GetTempFolder(),
                 DownloadFolder = _folderService.GetDownloadFolder(),
                 DownloadFileName = FilenameWildcards.DATE + "_" + FilenameWildcards.ID + "_" + FilenameWildcards.GAME,
+                DownloadQuality = VideoQuality.Source,
                 DownloadRemoveCompleted = false,
                 DownloadDisableConversion = false,
                 MiscUseExternalPlayer = false,


### PR DESCRIPTION
There are 5 commits:
Show filename, crop time in downloads tab.
Add 3 new wildcards with hyphen.
Add special wildcard, that will be replaced by some number to avoid overwrite.
Add new settings option - quality by default. Will be selected ONLY if this quality exist, in other cases you has to select quality manually (as now).
Add autosplit option (with special setting in preferences). You can download video by part automatically, with extra overlap option. Work only with conversation.

This is almost same changes, full tested