### PR TITLE
Search parses CropStartTime from url if present

### DIFF
--- a/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
+++ b/TwitchLeecher/TwitchLeecher.Core/Models/TwitchVideo.cs
@@ -108,6 +108,8 @@ namespace TwitchLeecher.Core.Models
 
         public Uri Url { get; }
 
+        public TimeSpan StartTime { get; set; }
+
         #endregion Properties
     }
 }

--- a/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
+++ b/TwitchLeecher/TwitchLeecher.Gui/ViewModels/SearchResultViewVM.cs
@@ -183,7 +183,7 @@ namespace TwitchLeecher.Gui.ViewModels
                             string filename = _filenameService.SubstituteWildcards(currentPrefs.DownloadFileName, video);
                             filename = _filenameService.EnsureExtension(filename, currentPrefs.DownloadDisableConversion);
 
-                            DownloadParameters downloadParams = new DownloadParameters(video, vodAuthInfo, video.Qualities.First(), folder, filename, currentPrefs.DownloadDisableConversion);
+                            DownloadParameters downloadParams = new DownloadParameters(video, vodAuthInfo, video.Qualities.First(), folder, filename, currentPrefs.DownloadDisableConversion) { CropStartTime = video.StartTime, CropStart = video.StartTime != TimeSpan.Zero };
 
                             _navigationService.ShowDownload(downloadParams);
                         }


### PR DESCRIPTION
I download a lot of videos that are given by links that contain a timestamp (e.g. https://www.twitch.tv/videos/1021452561?t=16960s).

When searching for the video based on the url, the timestamp is discarded, and the user has to manually input it. This is extra-annoying if the timestamp is given in seconds only (as in the example) instead of hours, minutes and seconds.

This pull request adds parsing of the timestamp from the url and forwarding it to the download.